### PR TITLE
update annotations for engine runtime defined fields

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,12 +6,16 @@
     "doscript": "require",
     "lazyimport": "require"
   },
-  "Lua.runtime.version": "Lua 5.1",
-  "Lua.telemetry.enable": false,
+  "Lua.runtime.version": "LuaFA",
   "Lua.workspace.checkThirdParty": false,
   "Lua.runtime.path": ["/?"],
   "Lua.runtime.plugin": ".vscode/fa-plugin.lua",
-  "Lua.workspace.ignoreDir": [".vscode", "loc", "*.bp", "lua/ui/lobby/changelog/generated/*"],
+  "Lua.workspace.ignoreDir": [
+    ".vscode",
+    "loc",
+    "*.bp",
+    "lua/ui/lobby/changelog/generated/*"
+  ],
   "[lua]": {
     "editor.wordBasedSuggestions": "off"
   },
@@ -25,10 +29,10 @@
   "Lua.completion.autoRequire": false,
   "Lua.diagnostics.globals": ["ScenarioInfo", "__moduleinfo"],
   "Lua.format.defaultConfig": {
-    "max_line_length": "unset",
+    "max_line_length": "unset"
   },
   "[markdown]": {
-    "editor.tabSize": 2,
+    "editor.tabSize": 2
   },
 
   // used for grammar checks of changelog

--- a/engine/AnnotationCommon.lua
+++ b/engine/AnnotationCommon.lua
@@ -9,7 +9,7 @@
 ---@class CScriptObject : userdata
 
 ---@class InternalObject : Destroyable
----@field _c_object CScriptObject
+---@field _c_object EngineDefinedField <CScriptObject>
 
 ---@class Destroyable
 local Destroyable = {}

--- a/engine/Core/Blueprints/Blueprint.lua
+++ b/engine/Core/Blueprints/Blueprint.lua
@@ -1,5 +1,8 @@
 ---@meta
 
+-- nilable alias used for fields that are defined in the engine (purely to prevent undefined field errors in the lua language server)
+---@alias EngineDefinedField<T> T | nil
+
 ---@alias BlueprintId string
 
 ---@class Blueprint
@@ -10,12 +13,12 @@
 ---     Merge = true,
 --- would let you change the blueprint of the Snoop UEF Land Scout without needing to add everything
 --- in the original definition (which could change or be modified by other mods).
----@field BlueprintId BlueprintId
+---@field BlueprintId EngineDefinedField <BlueprintId>
 --- Setting `Merge = true` will make the blueprint definition merge with an already existing one
 --- given by `BlueprintId` (which must also be set to an existing blueprint id).
 ---@field Merge? boolean
 --- the file the blueprint was originally defined in
----@field Source string
+---@field Source EngineDefinedField <string>
 
 ---@alias SoundLodCutoff
 ---| "DefaultLodCutoff"
@@ -29,4 +32,4 @@
 --- the sound cue inside of the sound bank to use
 ---@field Cue string
 --- unknown usage
----@field LodCutoff SoundLodCutoff
+---@field LodCutoff EngineDefinedField <SoundLodCutoff>

--- a/engine/Core/Blueprints/EntityBlueprint.lua
+++ b/engine/Core/Blueprints/EntityBlueprint.lua
@@ -14,50 +14,50 @@
 --- list of categories to remove during blueprint loading (for merge blueprints)
 ---@field DelCategories? CategoryName[]
 --- shape to use for collisions with the entity
----@field CollisionShape CollisionShape
+---@field CollisionShape EngineDefinedField <CollisionShape>
 --- the desired maximum number of shooters taking shots at the entity
----@field DesiredShooterCap number
+---@field DesiredShooterCap EngineDefinedField <number>
 --- Unit footprint. If absent, uses the `SizeX` and `SizeZ` fields.
 ---@field Footprint? FootprintBlueprint
 --- component X,X of inertia tensor
----@field InertiaTensorX number
+---@field InertiaTensorX EngineDefinedField <number>
 --- component Y,Y of inertia tensor
----@field InertiaTensorY number
+---@field InertiaTensorY EngineDefinedField <number>
 --- component Z,Z of inertia tensor
----@field InertiaTensorZ number
+---@field InertiaTensorZ EngineDefinedField <number>
 --- height of lifebar in OGrids
 ---@field LifeBarHeight number
 --- vertical offset of the lifebar from the entity
 ---@field LifeBarOffset number
 --- if the life bar is rendered or not
----@field LifeBarRender boolean
+---@field LifeBarRender EngineDefinedField <boolean>
 --- size of lifebar in OGrids
 ---@field LifeBarSize number
 --- module defining entity's class
----@field ScriptModule FileName
+---@field ScriptModule EngineDefinedField <FileName>
 --- name of entity's class
----@field ScriptClass string
+---@field ScriptClass EngineDefinedField <string>
 --- x offset from center of the entity's selection box
----@field SelectionCenterOffsetX number
+---@field SelectionCenterOffsetX EngineDefinedField <number>
 --- y offset from center of the entity's selection box
----@field SelectionCenterOffsetY number
+---@field SelectionCenterOffsetY EngineDefinedField <number>
 --- y offset from center of the entity's selection box
----@field SelectionCenterOffsetZ number
+---@field SelectionCenterOffsetZ EngineDefinedField <number>
 --- how far to reduce the top of the collision box for selection (defaults to 0.5)
 ---@field SelectionYOffset? number
 --- Scale the mesh on the X axis by this much when we perform our mouse over entity test
----@field SelectionMeshScaleX number
+---@field SelectionMeshScaleX EngineDefinedField <number>
 --- Scale the mesh on the Y axis by this much when we perform our mouse over entity test
----@field SelectionMeshScaleY number
+---@field SelectionMeshScaleY EngineDefinedField <number>
 --- Scale the mesh on the Z axis by this much when we perform our mouse over entity test
----@field SelectionMeshScaleZ number
+---@field SelectionMeshScaleZ EngineDefinedField <number>
 --- Use this much of the top portion of our mesh for intersection test. Useful for naval stuctures
 --- that go deep into water
----@field SelectionMeshUseTopAmount number
+---@field SelectionMeshUseTopAmount EngineDefinedField <number>
 --- x size of the entity's selection box
 ---@field SelectionSizeX number
 --- y size of the entity's selection box
----@field SelectionSizeY number
+---@field SelectionSizeY EngineDefinedField <number>
 --- z size of the entity's selection box
 ---@field SelectionSizeZ number
 --- Use this to modify the thickness of the rendered selection indicator for the unit
@@ -71,12 +71,12 @@
 --- icons were created in and the sort priority of the surrounding icons) 
 ---@field StrategicIconSortPriority integer
 --- Use OOB hit test for this unit when camera is below this zoom level
----@field UseOOBTestZoom number
+---@field UseOOBTestZoom EngineDefinedField <number>
 
 ---@class HitBox
----@field CollisionOffsetX number
----@field CollisionOffsetY number
----@field CollisionOffsetZ number
+---@field CollisionOffsetX EngineDefinedField <number>
+---@field CollisionOffsetY EngineDefinedField <number>
+---@field CollisionOffsetZ EngineDefinedField <number>
 ---@field SizeX number
 ---@field SizeY number
 ---@field SizeZ number

--- a/engine/Core/Blueprints/MeshBlueprint.lua
+++ b/engine/Core/Blueprints/MeshBlueprint.lua
@@ -7,25 +7,25 @@
 --- zoomed out you must be for the icon to appear.
 ---@field IconFadeInZoom number
 --- sort order of mesh we render smallest to largest
----@field SortOrder number
+---@field SortOrder EngineDefinedField <number>
 --- uniform scale factor
----@field UniformScale number
+---@field UniformScale EngineDefinedField<number>
 --- render both above and below the water
----@field StraddleWater boolean
+---@field StraddleWater EngineDefinedField <boolean>
 
 ---@class MeshBlueprintLod
 --- name of mesh to use for this LOD
----@field MeshName FileName
+---@field MeshName EngineDefinedField <FileName>
 --- name of the albedo to use for this LOD
----@field AlbedoName FileName
+---@field AlbedoName EngineDefinedField <FileName>
 --- name of the normal map to use for this LOD
----@field NormalsName FileName
+---@field NormalsName EngineDefinedField <FileName>
 --- name of the specular map to use for this LOD
----@field SpecularName FileName
+---@field SpecularName EngineDefinedField <FileName>
 --- name of the lookup map to use for this LOD
 ---@field LookupName FileName
 --- name of the secondary map to use for this LOD
----@field SecondaryName FileName
+---@field SecondaryName EngineDefinedField <FileName>
 --- the shader name from `Mesh.fx` to use for this LOD
 ---@field ShaderName? string
 --- name of the texture map to use for this LOD

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -38,7 +38,7 @@
 ---@class UnitBlueprint: EntityBlueprint
 --- Table keyed with a `ScriptTask`'s `TaskName` that determines the properties of the order button for that ability.
 --- The `OrderInfo.behavior` is overwritten in `orders.lua`.
----@field Abilities table<string, OrderInfo>
+---@field Abilities EngineDefinedField <table<string, OrderInfo>>
 --- the number of build bots a Cybran builder has
 ---@field BuildBotTotal? number
 --- set to an integer that describes the unit's position in the list of build icons
@@ -67,9 +67,9 @@
 --- `CollisionSphereOffset` species of collision offsets
 ---@field SizeSphere? number
 --- Whether this unit uses the mass-based veterancy system
----@field VetEnabled boolean
+---@field VetEnabled EngineDefinedField <boolean>
 --- Defines threshold when 
----@field VetThresholds table<number, number>
+---@field VetThresholds EngineDefinedField <table<number, number>>
 --- overrides the veterancy instant heal multiplier per level (which is 0.1)
 ---@field VeteranHealingMult? number[]
 --- Additional mass needed to get to the veterancy level of the index in the table, relative to the
@@ -83,11 +83,11 @@
 --- destroyed. Defaults to bone `0`
 ---@field WatchBone? Bone
 ---
----@field AI UnitBlueprintAI
----@field Air UnitBlueprintAir
+---@field AI EngineDefinedField <UnitBlueprintAI>
+---@field Air EngineDefinedField <UnitBlueprintAir>
 ---@field Adjacency UnitBlueprintAdjacency|string
 ---@field Audio? UnitBlueprintAudio
----@field Buffs BlueprintBuff[]
+---@field Buffs EngineDefinedField <BlueprintBuff[]>
 ---@field Defense UnitBlueprintDefense
 ---@field Display UnitBlueprintDisplay
 ---@field Economy UnitBlueprintEconomy
@@ -95,8 +95,8 @@
 ---@field Enhancements?  table<Enhancement, UnitBlueprintEnhancement>
 ---@field EnhancementPresets? table<string, UnitBlueprintEnhancementPreset>
 ---@field General UnitBlueprintGeneral
----@field Intel UnitBlueprintIntel
----@field Interface UnitBlueprintInterface
+---@field Intel EngineDefinedField <UnitBlueprintIntel>
+---@field Interface EngineDefinedField <UnitBlueprintInterface>
 ---@field Physics UnitBlueprintPhysics
 ---@field Transport? UnitBlueprintTransport
 ---@field Veteran? UnitBlueprintVeterancy
@@ -106,23 +106,23 @@
 ---
 --- Auto-generated unit id from the folder name. When modifying a blueprint, this must be defined to
 --- the blueprint id it is modifying instead.
----@field BlueprintId UnitId
+---@field BlueprintId EngineDefinedField <UnitId>
 --- auto-generated categories table based on `Categories` with each key a value in that array
----@field CategoriesHash table<CategoryName, true>
+---@field CategoriesHash EngineDefinedField <table<CategoryName, true>>
 --- auto-generated for unit blueprints generated from a unit with a preset in `EnhancementPresets`
 ---@field EnhancementPresetAssigned? UnitBlueprintAssignedEnhancementPreset
 --- auto-generated faction category from `Categories`
----@field FactionCategory FactionCategory
+---@field FactionCategory EngineDefinedField <FactionCategory>
 --- auto-generated later category from `Categories`
----@field LayerCategory LayerCategory
+---@field LayerCategory EngineDefinedField <LayerCategory>
 --- auto-generated volume based on `SizeX`, `SizeY`, and `SizeZ`
----@field SizeVolume number
+---@field SizeVolume EngineDefinedField <number>
 --- auto-generated damage effects size based on `SizeVolume`
----@field SizeDamageEffects number
+---@field SizeDamageEffects EngineDefinedField <number>
 --- auto-generated damage effects size scale based on `SizeVolume`
----@field SizeDamageEffectsScale number
+---@field SizeDamageEffectsScale EngineDefinedField <number>
 --- auto-generated tech category from `Categories`
----@field TechCategory TechCategory
+---@field TechCategory EngineDefinedField <TechCategory>
 ---
 --- adds categories to `Categories` and then is deleted. Takes precedence over `DelCategories`
 ---@field AddCategories? CategoryName[]
@@ -134,17 +134,17 @@
 --- At what angle (to either side) the unit attacks its target after getting an attack order. 
 --- If one of the unit's weapons has a target and has `SlavedToBody = true`, it will rotate when idle and attacking.
 --- Overrides Weapon `SlavedToBody` and `SlavedToBodyArcRange` behavior.
----@field AttackAngle number
+---@field AttackAngle EngineDefinedField <number>
 --- automatically surface to attack ground targets
----@field AutoSurfaceToAttack boolean
+---@field AutoSurfaceToAttack EngineDefinedField <boolean>
 --- this is the beacon that this unit will create under some circumstances
----@field BeaconName string
+---@field BeaconName EngineDefinedField <string>
 --- the formation name used for guarding this unit
----@field GuardFormationName string
+---@field GuardFormationName EngineDefinedField <string>
 --- how far a unit on patrol will look off it's patrol path to go attack
----@field GuardRadius number
+---@field GuardRadius EngineDefinedField <number>
 --- maximum range from the guarded unit before initiating return
----@field GuardReturnRadius number
+---@field GuardReturnRadius EngineDefinedField <number>
 --- Guard scan range for the unit. The guard scan radius is used by attack move and patrol orders. Through this scanning mechanic the patrolling (or attack moving) unit can find a target to chase. The scanning behavior includes neutral units.
 ---
 --- Through a binary patch the guard scan radius is reset to 0 when the unit is not patrolling and/or attack moving:
@@ -156,17 +156,17 @@
 --- - https://github.com/FAForever/fa/pull/3892
 ---
 --- The value is automatically populated during blueprint loading to a sensible default if it is not set in the blueprint.
----@field GuardScanRadius number
+---@field GuardScanRadius EngineDefinedField <number>
 --- initial toggle of automatic behaviors (silo building and auto-assist)
 ---@see SetAutoMode
----@field InitialAutoMode boolean
+---@field InitialAutoMode EngineDefinedField <boolean>
 --- unit should unpack before firing weapon
 --- Engine sets tracking radius to 1x, calls OnLostTarget when given a move order, and OnGotTarget only when not moving
----@field NeedUnpack boolean
+---@field NeedUnpack EngineDefinedField <boolean>
 --- this muliplier is applied to an air unit's refuel rate when the staging platform is refueling it
----@field RefuelingMultiplier number
+---@field RefuelingMultiplier EngineDefinedField <number>
 --- this amount of repair per **second** is offered to refueling air units
----@field RefuelingRepairAmount number
+---@field RefuelingRepairAmount EngineDefinedField <number>
 --- this amount of energy per **tick** is required to repair the air unit
 ---@field RepairConsumeEnergy? number
 --- this amount of mass per **tick** is required to repair the air unit
@@ -177,7 +177,7 @@
 ---@field StagingPlatformScanRadius? number
 --- Names of bones for other units to try to aim at instead of the default center pos.
 --- The center pos is calculated using Size values but doesn't use CollisionOffset values.
----@field TargetBones string[]
+---@field TargetBones EngineDefinedField <string[]>
 
 
 ---@class UnitBlueprintAir
@@ -371,7 +371,7 @@
 ---@field MaxHealth number
 --- Default amount of health to regenerate per second for the unit.
 --- (It could be changed by a veterancy buff or enhancement)
----@field RegenRate number
+---@field RegenRate EngineDefinedField <number>
 --- if the unit has a shield, the settings are held in a table here
 ---@field Shield? UnitBlueprintDefenseShield
 --- if the various threat levels are not to be auto-generated at all for this unit
@@ -384,7 +384,7 @@
 --- how much anti-air it has.
 --- Different AI's can interpret this value differently (for example, the `SurfaceThreatLevel` may
 --- be added in its calculations).
----@field AirThreatLevel number
+---@field AirThreatLevel EngineDefinedField <number>
 --- An auto-generated value representing the threat this unit poses to the enemy due to an
 --- "economy score" calculated when the blueprint is loaded.
 --- Different AI's can interpret the result differently.
@@ -392,11 +392,11 @@
 --- An auto-generated value representing the threat this unit poses to the enemy units in the
 --- submarine layer based on how much anti-navy it has.
 --- Different AI's can interpret this value differently.
----@field SubThreatLevel number
+---@field SubThreatLevel EngineDefinedField <number>
 --- An auto-generated value representing the threat this unit poses to enemy surface units based on
 --- how much direct fire, indirect fire, and bombing capability it has.
 --- Different AI's can interpret this value differently.
----@field SurfaceThreatLevel number
+---@field SurfaceThreatLevel EngineDefinedField <number>
 
 ---@class UnitBlueprintDefenseShield
 --- If this shield only blocks weapons marked with `ArtilleryShieldBlocks`.
@@ -483,16 +483,16 @@
 --- Backup abilities shown by the unit view, if the detected ones don't cover them.
 ---@field Abilities UnlocalizedString[]
 --- names that the AI can use to name the unit, provided the AI is programmed to do this
----@field AINames UnlocalizedString[]
+---@field AINames EngineDefinedField <UnlocalizedString[]>
 --- The animation that is played when the unit is completed
 --- (seen in experimentals, e.g. Megalith - XRL0403)
----@field AnimationActivate FileName
+---@field AnimationActivate EngineDefinedField <FileName>
 --- Animation that is played when the unit is building
 ---@field AnimationBuild? FileName
 --- How fast the build animation plays. Treated as `1` if absent.
 ---@field AnimationBuildRate? number
 --- The table of animations shown at death. One will be randomly pulled.
----@field AnimationDeath UnitBlueprintAnimationDeath[]
+---@field AnimationDeath EngineDefinedField <UnitBlueprintAnimationDeath[]>
 --- used by the XRB2309 (submerged HARMS) script
 ---@field AnimationDeploy? FileName
 --- factories will play this animation on land units they build
@@ -514,18 +514,18 @@
 --- used by the URS0201 (Salem class destroyer) script
 ---@field AnimationTransform? FileName
 --- the animation that is played when the unit is upgrading
----@field AnimationUpgrade FileName
+---@field AnimationUpgrade EngineDefinedField <FileName>
 --- A table of animations to use while upgrading, depending on the unit it is upgrading to.
 ---@field AnimationUpgradeTable? table<UnitId, FileName>
 --- Full path to file. Base game path is typically `'/units/UnitID/UnitID_awalk.sca'` but mods should use their mod path `'/mods/ModName/...'`.
 ---@field AnimationWalk? FileName
 --- controls the speed of the animation. Adjusting this number can cause or prevent "skating"
----@field AnimationWalkRate number
+---@field AnimationWalkRate EngineDefinedField <number>
 --- used by UEF and Cybran construction units to animate their hover transition
 ---@field AnimationWater? FileName
 ---@field AttackReticleSize? number unused
----@field BlinkingLights UnitBlueprintBlinkingLightsData[]
----@field BlinkingLightsFx UnitBlueprintBlinkingLightsFx
+---@field BlinkingLights EngineDefinedField <UnitBlueprintBlinkingLightsData[]>
+---@field BlinkingLightsFx EngineDefinedField <UnitBlueprintBlinkingLightsFx>
 --- the bone on factories where units are built
 ---@field BuildAttachBone? Bone
 --- used while cloaked
@@ -539,7 +539,7 @@
 ---@field HideLifebars? boolean
 --- Effects displayed when the unit is idle (e.g. glow beneath hovering units), multiple layers can
 --- be used. The key should be the name of the layer where effects should be displayed
----@field IdleEffects table<Layer, UnitBlueprintEffects>
+---@field IdleEffects EngineDefinedField <table<Layer, UnitBlueprintEffects>>
 --- used by the URS0201 (Salem class destroyer) script 
 ---@field LandAnimationDeath? {Animation: FileName, Weight: number}
 --- effects displayed when the unit changes layers (e.g. when an aircraft lands or takes off)
@@ -547,23 +547,23 @@
 --- first one is the old layer and the second is the new one. E.g. effects are needed for an
 --- aircraft landing, so the old layer is Air and the new one is Land, then the 'string' will be
 --- airLand (LandAir would be the opposite - take off). Note: there is NO space between layer names
----@field LayerChangeEffects table<LayerChangeType, UnitBlueprintEffects>
+---@field LayerChangeEffects EngineDefinedField <table<LayerChangeType, UnitBlueprintEffects>>
 --- used by the XSB1102 (Seraphim hydrocarbon powerplant) script
 ---@field LoopingAnimation? FileName
 ---@field MaxRockSpeed? number
 ---@field Mesh MeshBlueprint
----@field MeshBlueprint FileName
+---@field MeshBlueprint EngineDefinedField <FileName>
 --- used for the wreackge if `Wreckage.UseCustomMesh` is set
 ---@field MeshBlueprintWrecked? FileName
 --- used by the XSB2401 (Yolona Oss) script
 ---@field MissileBone? Bone
----@field MotionChangeEffects table<MotionChangeType, UnitBlueprintEffects>
+---@field MotionChangeEffects EngineDefinedField <table<MotionChangeType, UnitBlueprintEffects>>
 --- Effects displayed during movement of the unit. Key should be Name of the layer for which the
 --- effects are displayed.
----@field MovementEffects table<Layer, UnitBlueprintEffects>
----@field PlaceholderMeshName string
+---@field MovementEffects EngineDefinedField <table<Layer, UnitBlueprintEffects>>
+---@field PlaceholderMeshName EngineDefinedField <string>
 ---@field ShowBuildEffectsDuringUpgrade? boolean
----@field SpawnRandomRotation boolean
+---@field SpawnRandomRotation EngineDefinedField <boolean>
 ---@field Tarmacs UnitBlueprintTarmac[]
 ---@field TerrainMeshes? table<TerrainStyle, FileName>
 ---@field TransportAnimation? FileName
@@ -578,7 +578,7 @@
 ---@field WaterAnimationDeath? {}                   
 ---
 --- auto-generated field that points to the mesh to use while building
----@field BuildMeshBlueprint BlueprintId
+---@field BuildMeshBlueprint EngineDefinedField <BlueprintId>
 
 ---@class UnitBlueprintAnimationDeath
 --- Full path of the animation file. Typically `'/units/UnitID/UnitID_ADeath.sca'` but mods should use their mod path `'/mods/ModName/...'`.
@@ -691,12 +691,12 @@
 
 ---@class UnitBlueprintTarmac
 ---@field Albedo FileName
----@field Albedo2 FileName
+---@field Albedo2 EngineDefinedField <FileName>
 ---@field DeathLifetime number
 ---@field FadeOut number
 ---@field Length number
 ---@field Normal FileName
----@field Glow FileName
+---@field Glow EngineDefinedField <FileName>
 ---@field Orientations number[]
 ---@field RemoveWhenDead boolean
 ---@field Width number
@@ -707,18 +707,18 @@
 ---@field AdjacentMassProductionMod? number
 ---@field AdjacentStructureEnergyMod? number
 --- Defines what units can be built. Used by the engine.
----@field BuildableCategory UnparsedCategory[]
+---@field BuildableCategory EngineDefinedField <UnparsedCategory[]>
 --- Defines what buildable units can only be produced through upgrading. Used in Lua.
----@field UpgradeOnlyCategory UnparsedCategory[]
+---@field UpgradeOnlyCategory EngineDefinedField <UnparsedCategory[]>
 --- energy cost to build this unit
----@field BuildCostEnergy number
+---@field BuildCostEnergy EngineDefinedField <number>
 --- mass cost to build this unit
----@field BuildCostMass number
+---@field BuildCostMass EngineDefinedField <number>
 --- how fast this unit build other units
----@field BuildRate number
+---@field BuildRate EngineDefinedField <number>
 --- the needed time when producing this unit; this is only a factor of time,
 --- not the real time to produce the unit
----@field BuildTime number
+---@field BuildTime EngineDefinedField <number>
 --- present in UEF engineering drones
 ---@field BuildRadius? number
 --- What unit spawns out of the egg. Used by `CConstructionEggUnit` (Megalith's crab eggs)
@@ -731,9 +731,9 @@
 ---@field DifferentialUpgradeCostCalculation? boolean
 ---@field EngineeringPods? {CreateWithUnit: boolean, PodAttachpoint: Bone, PodName: string, PodUnitID: UnitId}
 --- default rally point X for the factory
----@field InitialRallyX number
+---@field InitialRallyX EngineDefinedField <number>
 --- default rally point Z for the factory
----@field InitialRallyZ number
+---@field InitialRallyZ EngineDefinedField <number>
 --- Total energy drain when changing scrying locations. Used by XAB3301 (Eye of Rhianne)
 ---@field InitialRemoteViewingEnergyDrain? number
 --- amount that define which amount of energy the unit is consuming per second; Used for Shields
@@ -741,22 +741,22 @@
 ---@field MaintenanceConsumptionPerSecondMass? number
 --- Maximum build range of the unit. The target must be within this range before the
 --- builder can perform operation.
----@field MaxBuildDistance number
+---@field MaxBuildDistance EngineDefinedField <number>
 --- used by XAB1401 (Paragon) script
 ---@field MaxEnergy? number
 --- used by XAB1401 (Paragon) script
 ---@field MaxMass? number
----@field MinBuildTime number
+---@field MinBuildTime EngineDefinedField <number>
 ---@field MinConsumptionPerSecondEnergy? number
 ---@field MinConsumptionPerSecondMass? number
 --- produces resource naturally and does not consume anything
----@field NaturalProducer boolean
+---@field NaturalProducer EngineDefinedField <boolean>
 --- builder needs to face target before it can build/repair
----@field NeedToFaceTargetToBuild boolean
+---@field NeedToFaceTargetToBuild EngineDefinedField <boolean>
 --- amount of energy produced per second
----@field ProductionPerSecondEnergy number
+---@field ProductionPerSecondEnergy EngineDefinedField <number>
 --- amount of mass produced per second
----@field ProductionPerSecondMass number
+---@field ProductionPerSecondMass EngineDefinedField <number>
 --- You will get a bonus if you rebuild this unit over the wreckage of these wreckages.
 --- Multible BonusID's can be added.
 ---@field RebuildBonusIds? string[]
@@ -960,34 +960,34 @@
 
 ---@class UnitBlueprintGeneral
 ---@field BuildBones? BuildBones
----@field BuildBonesAlt1 BuildBones
+---@field BuildBonesAlt1 EngineDefinedField <BuildBones>
 --- Cost of the unit towards unit cap (default is 1.0)
----@field CapCost number
----@field Category string
----@field Classification UnitClassification
+---@field CapCost EngineDefinedField <number>
+---@field Category EngineDefinedField <string>
+---@field Classification EngineDefinedField <UnitClassification>
 --- command capability flags for this unit
----@field CommandCaps table<CommandCap, boolean>
+---@field CommandCaps EngineDefinedField <table<CommandCap, boolean>>
 ---@field ExcludeFromVeterancy? boolean
 --- Faction the unit belongs to.
----@field FactionName FactionName
+---@field FactionName EngineDefinedField <FactionName>
 ---@field FractionThreshold? number
 --- indicates the background for the build icon
----@field Icon IconBackgroundType
+---@field Icon EngineDefinedField <IconBackgroundType>
 --- if the unit always self-destructs immediately, skipping any countdown sequence
 ---@field InstantDeathOnSelfDestruct? boolean
----@field OrderOverrides table<CommandCap, OrderInfo>
+---@field OrderOverrides EngineDefinedField <table<CommandCap, OrderInfo>>
 --- indicates unit has it's own avatar button in the quick select interface,
 --- and it's sorting priority
----@field QuickSelectPriority integer
+---@field QuickSelectPriority EngineDefinedField <integer>
 --- how long to wait before rolling the unit off the factory
 ---@field RolloffDelay? number
 --- Determines if a unit will be selected in a drag selection, only the highest priority units will
 --- get selected (1 is highest).
----@field SelectionPriority integer
+---@field SelectionPriority EngineDefinedField <integer>
 ---@field TarmacDecal? any unused
 ---@field TarmacGlowDecal? any unused
 --- defines the tech level used for display purposes
----@field TechLevel UnitTechLevel
+---@field TechLevel EngineDefinedField <UnitTechLevel>
 --- Extra time taken to teleport before other teleport time calculations. Defaults to 0 seconds.
 --- If `UseVariableTeleportCosts` is false, then this also delays teleport FX appearing at the destination.
 --- If `UseVariableTeleportCosts` is true, then destination FX appear after 0.4x the total teleport time.
@@ -1000,12 +1000,12 @@
 --- Only applies when `UseVariableTeleportCosts` is true. Defaults to 50 seconds.
 ---@field TeleportMaximumDuration? number
 --- table of toggle capabilities available for this unit
----@field ToggleCaps table<ToggleCap, boolean>
+---@field ToggleCaps EngineDefinedField <table<ToggleCap, boolean>>
 --- table of boolean toggles set/got with SetStatByCallback/GetStat
----@field StatToggles table<string, table>
+---@field StatToggles EngineDefinedField <table<string, table>>
 --- name of the unit
----@field UnitName UnlocalizedString
----@field UnitWeight number unused
+---@field UnitName EngineDefinedField <UnlocalizedString>
+---@field UnitWeight EngineDefinedField <number> unused
 --- what unit, if any, this unit can be upgraded from
 ---@field UpgradesFrom? UnitId
 --- what unit, if any, this unit can be upgraded to
@@ -1014,7 +1014,7 @@
 ---@field UpgradesFromBase? UnitId
 ---
 --- auto-generated field from `CommandCaps`
----@field CommandCapsHash table<CommandCap, true>
+---@field CommandCapsHash EngineDefinedField <table<CommandCap, true>>
 
 ---@class BuildBones
 --- the bone that gets aimed that what the unit is building
@@ -1028,10 +1028,10 @@
 
 ---@class UnitIntelStatus
 ---@field RechargeThread thread?
----@field AllIntel table<IntelType, boolean>
----@field AllIntelRecharging table<IntelType, boolean>
----@field AllIntelMaintenanceFree table<IntelType, boolean>
----@field AllIntelDisabledByEvent table<IntelType, table<string, boolean>>
+---@field AllIntel EngineDefinedField <table<IntelType, boolean>>
+---@field AllIntelRecharging EngineDefinedField <table<IntelType, boolean>>
+---@field AllIntelMaintenanceFree EngineDefinedField <table<IntelType, boolean>>
+---@field AllIntelDisabledByEvent EngineDefinedField <table<IntelType, table<string, boolean>>>
 
 ---@class UnitBlueprintIntel
 --- intel status that is deep-copied for each unit instance
@@ -1095,81 +1095,81 @@
 
 ---@class UnitBlueprintPhysics
 --- Forces terrain alignment for structures
----@field AltitudeToTerrain boolean
+---@field AltitudeToTerrain EngineDefinedField <boolean>
 --- forces terrain alignment for structures
----@field AlwaysAlignToTerrain boolean
+---@field AlwaysAlignToTerrain EngineDefinedField <boolean>
 --- alternate method of locomotion
 ---@field AltMotionType? UnitMotionType
 --- preferred attack height when attacking ground targets (used by dive bombers)
----@field AttackElevation number
+---@field AttackElevation EngineDefinedField <number>
 --- distance that the unit will just back up if it is easier to do so
----@field BackUpDistance number
+---@field BackUpDistance EngineDefinedField <number>
 --- how much the unit banks in corners (negative to lean outwards)
----@field BankingSlope number
+---@field BankingSlope EngineDefinedField <number>
 --- unit may be built on these layers (only applies to structures)
----@field BuildOnLayerCaps table<LayerEnum, boolean>
+---@field BuildOnLayerCaps EngineDefinedField <table<LayerEnum, boolean>>
 --- special build restrictions (mass deposit, thermal vent, etc)
----@field BuildRestriction UnitBuildRestriction
+---@field BuildRestriction EngineDefinedField <UnitBuildRestriction>
 --- acceleration to allow unit to catch up to the target when it starts to drift
----@field CatchUpAcc number
+---@field CatchUpAcc EngineDefinedField <number>
 --- unknown if significant in `Physics`
 ---@field CollisionOffsetX? number
 --- if a naval factory uses the special rolloff point computation
 ---@field ComputeRollOffPoint? boolean
 ---@field DragCoefficient number unused
 --- preferred height above (negative for below) land or water surface
----@field Elevation number
+---@field Elevation EngineDefinedField <number>
 --- if true, terrain under building's skirt will be flattened
 ---@field FlattenSkirt boolean
----@field Footprint FootprintBlueprint
+---@field Footprint EngineDefinedField <FootprintBlueprint>
 --- unit fuels up at this rate per second. Required for air staging to undock automatically.
----@field FuelRechargeRate number
+---@field FuelRechargeRate EngineDefinedField <number>
 --- unit has fuel for this number of seconds. Required for air staging to undock automatically.
----@field FuelUseTime number
+---@field FuelUseTime EngineDefinedField <number>
 --- How much the collision model is offset from the ground. Used to make aircraft land properly.
 ---@field GroundCollisionOffset? number
 --- Used in combination with `FlattenSkirt` to guarantee the result is completely horizontal
----@field HorizontalSkirt boolean
+---@field HorizontalSkirt EngineDefinedField <boolean>
 --- used by XSL0305 (Seraphim sniper bot) script as the speed multiplier during the reload of the alternate sniper mode
 --- also used by URS0201 (Salem class destroyer) script as the speed multiplier when walking on land
 ---@field LandSpeedMultiplier? number
 --- an offset to the layer change height used during the transition between seabed/water and land
----@field LayerChangeOffsetHeight number
+---@field LayerChangeOffsetHeight EngineDefinedField <number>
 --- transition time in seconds when going from water/land and land/water
----@field LayerTransitionDuration number
+---@field LayerTransitionDuration EngineDefinedField <number>
 --- maximum acceleration for the unit
----@field MaxAcceleration number
+---@field MaxAcceleration EngineDefinedField <number>
 --- maximum braking acceleration for the unit
----@field MaxBrake number
+---@field MaxBrake EngineDefinedField <number>
 --- maximum elevation difference across skirt for build site
----@field MaxGroundVariation number
+---@field MaxGroundVariation EngineDefinedField <number>
 --- maximum speed for the unit
----@field MaxSpeed number
+---@field MaxSpeed EngineDefinedField <number>
 --- maximum speed for the unit in reverse. Defaults to the same value as MaxSpeed
----@field MaxSpeedReverse number
+---@field MaxSpeedReverse EngineDefinedField <number>
 --- maximum steer force magnitude that can be applied to acceleration
----@field MaxSteerForce number
+---@field MaxSteerForce EngineDefinedField <number>
 --- Used by some build animations to scale their effects
 ---@field MeshExtentsX number
 --- Used by some build animations to scale their effects
 ---@field MeshExtentsY number
 --- Used by some build animations to scale their effects
 ---@field MeshExtentsZ number
----@field MinSpeedPercent number
+---@field MinSpeedPercent EngineDefinedField <number>
 --- method of locomotion
 ---@field MotionType UnitMotionType
 --- The occupy rectangles of the unit that will override the footprint. Every 4 numbers in the
 --- array define a occupation rectangle for the override (offsetX, offsetZ, sizeX, sizeZ).
----@field OccupyRects number[]
+---@field OccupyRects EngineDefinedField <number[]>
 --- Raised platform definition for ground units to move on. Every 3 numbers define a point relative
 --- to the center (x, z, height), and every 4 points (or 12 numbers) defines a platform.
----@field RaisedPlatforms number[]
+---@field RaisedPlatforms EngineDefinedField <number[]>
 --- how much damping there is against rolling motion (1 = no motion at all)
----@field RollDamping number
+---@field RollDamping EngineDefinedField <number>
 --- how stable the unit is against rolling (0 to 1)
----@field RollStability number
+---@field RollStability EngineDefinedField <number>
 --- The set of rolloff points available for a factory unit.
----@field RollOffPoints UnitRollOffPoint[]
+---@field RollOffPoints EngineDefinedField <UnitRollOffPoint[]>
 --- ability to rotate body to aim weapon "slaved" to body while in still in motion
 ---@field RotateBodyWhileMoving? boolean
 --- if this unit can try to rotate on the spot
@@ -1189,25 +1189,25 @@
 --- unit construction pad Size Z for building
 ---@field SkirtSizeZ number
 --- Stands upright regardless of terrain
----@field StandUpright boolean
+---@field StandUpright EngineDefinedField <boolean>
 --- used by XSB3202 (T2 sonar) and XSS0201 (Destroyer) when the vertical layer changes from top to sub
 ---@field SubSpeedMultiplier? number
 --- How much this unit slows down transports it is loaded in.  
 --- Defaults to 0.15 (Tech 1), 0.3 (Tech 2), 0.6 (Tech 3), and 1 (ACU/SACU/Experimentals).
----@field TransportSpeedReduction number
+---@field TransportSpeedReduction EngineDefinedField <number>
 --- turn facing damping for the unit, usually used for hover units only
----@field TurnFacingRate number
+---@field TurnFacingRate EngineDefinedField <number>
 --- turn radius for the unit, in world units. Used when the nav waypoint is further than `TurnRadius` distance,
 --- and if it results in a faster turn rate than `TurnRate`. Disabled at 0
----@field TurnRadius number
+---@field TurnRadius EngineDefinedField <number>
 --- turn rate for the unit, in degrees per second. Turning acts improperly when at 0
----@field TurnRate number
+---@field TurnRate EngineDefinedField <number>
 --- when present, the speed multiplier is set to this number when entering the water layer
 ---@field WaterSpeedMultiplier? number
 --- how much wobbling for the unit while hovering
----@field WobbleFactor number
+---@field WobbleFactor EngineDefinedField <number>
 --- how fast is the wobble, the faster the less stable looking
----@field WobbleSpeed number
+---@field WobbleSpeed EngineDefinedField <number>
 ---
 --- auto-generated flag for naval factories
 ---@field CorrectNavalRollOffPoints? true

--- a/engine/Core/Blueprints/WeaponBlueprint.lua
+++ b/engine/Core/Blueprints/WeaponBlueprint.lua
@@ -33,15 +33,15 @@
 --- `moho.manipulator_methods:SetPrecedence(precedence)`. Treated as `10` when absent.
 ---@field AimControlPrecedence? number
 --- this weapon will aim straight ahead when disabled
----@field AimsStraightOnDisable boolean
+---@field AimsStraightOnDisable EngineDefinedField <boolean>
 --- always recheck for better target regardless of whether you already have one or not
----@field AlwaysRecheckTarget boolean
+---@field AlwaysRecheckTarget EngineDefinedField <boolean>
 --- animation played by the weapon's Rack Salvo Reload Sequence
 ---@field AnimationReload? FileName
 --- if an anti-artillery shield will block this projectile
 ---@field ArtilleryShieldBlocks? boolean
 --- information about the audio files used by the weapon
----@field Audio WeaponBlueprintAudio
+---@field Audio EngineDefinedField <WeaponBlueprintAudio>
 --- How many times the engine calls OnFire for the weapon when attacking ground before moving on to the next ground attack order. Defaults to 3
 ---@field AttackGroundTries? number
 --- if the unit has no issued commands and has a weapon that has `AutoInitiateAttackCommand` set,
@@ -50,15 +50,15 @@
 --- Ballistic arcs that should be used on the projectile
 ---@field BallisticArc? WeaponBallisticArc
 --- Interval in seconds between beam collision checks (which take 1 tick) - using `0` will cause beams to damage every tick
----@field BeamCollisionDelay number
+---@field BeamCollisionDelay EngineDefinedField <number>
 --- the amount of time the beam exists
----@field BeamLifetime number
+---@field BeamLifetime EngineDefinedField <number>
 --- if the weapon will only fire when underwater
 ---@field BelowWaterFireOnly? boolean
 --- Distance from bomb firing solution's position to the target's position within which the weapon will fire 
 ---@field BombDropThreshold? number
 --- information about the bonuses added to the weapon when it reaches a specific veterancy level
----@field Buffs BlueprintBuff[]
+---@field Buffs EngineDefinedField <BlueprintBuff[]>
 --- used by UEL0103 (Lobo) script to pass the lifetime of the vision marker created upon landing
 ---@field CameraLifetime? number
 --- time to maintain the camera shake
@@ -70,13 +70,13 @@
 --- used by UEL0103 (Lobo) script to pass the radius of the vision marker created upon landing
 ---@field CameraVisionRadius? number
 --- how far from the unit should the camera shake
----@field CameraShakeRadius number
+---@field CameraShakeRadius EngineDefinedField <number>
 --- if the weapon cannot attack ground positions
 ---@field CannotAttackGround? boolean
 --- should the unit collide against friendly meshes
----@field CollideFriendly boolean
+---@field CollideFriendly EngineDefinedField <boolean>
 --- beams fire without stopping - overrides `RateOfFire`
----@field ContinuousBeam boolean
+---@field ContinuousBeam EngineDefinedField <boolean>
 --- This projectile needs to be built and stored before the weapon can fire.
 --- Makes the engine check if the weapon has silo ammo before being allowed to fire.
 ---@field CountedProjectile? boolean
@@ -97,14 +97,14 @@
 --- See `moho.projectile_methods:ChangeDetonateAboveHeight(height)`
 ---@field DetonatesAtTargetHeight? boolean
 --- Disables the weapon while it is reloading
----@field DisableWhileReloading boolean
+---@field DisableWhileReloading EngineDefinedField <boolean>
 --- Name of the weapon. Used for lobby restrictions and for debugging:
 --- `dbg weapons` in the console shows the weapon names.
 ---@field DisplayName string
 --- number of times the Damage over Time damage will be dealt
----@field DoTPulses number
+---@field DoTPulses EngineDefinedField <number>
 --- duration that the Damage over Time will last in seconds
----@field DoTTime number
+---@field DoTTime EngineDefinedField <number>
 --- If `FixBombTrajectory` is set, then bombs dropped with this weapon will be aimed at the position
 --- this fraction of the distance between the target and where it dropped. This may only be useful
 --- for torpedo bombers.
@@ -113,7 +113,7 @@
 --- script object. This is for purely script driven weapons (like death weapons).
 ---@field DummyWeapon boolean
 --- the effective range that this weapon really has
----@field EffectiveRadius number
+---@field EffectiveRadius EngineDefinedField <number>
 --- if defined, will make this weapon not contribute to the automatically generated threat levels
 ---@field EnabledByEnhancement? Enhancement
 --- if `false`, the first shot out of this weapon will not create an economy drain event
@@ -142,14 +142,14 @@
 --- this value
 ---@field FixedSpreadRadius? number
 --- flares that this weapons launches
----@field Flare WeaponBlueprintFlare
+---@field Flare EngineDefinedField <WeaponBlueprintFlare>
 --- used to force packing up a weapon before being able to fire again
 ---@field ForceSingleFire? boolean
 --- controls what the weapon is allowed to target in reference to the heading of the unit. Defaults to 0
----@field HeadingArcCenter number
+---@field HeadingArcCenter EngineDefinedField <number>
 --- controls what the weapon is allowed to target in reference to the arc center,
 --- this is degrees on either side. Defaults to 180
----@field HeadingArcRange number
+---@field HeadingArcRange EngineDefinedField <number>
 --- does not consider the weapon when attacking targets if it is disabled
 ---@field IgnoreIfDisabled? boolean
 --- the intial damage done on impact for a Damage over Time weapon
@@ -175,38 +175,38 @@
 --- Defaults to nil, which gives infinite vertical range.
 ---@field MaxHeightDiff? number
 --- this weapon can only hold this many counted projectiles
----@field MaxProjectileStorage number
+---@field MaxProjectileStorage EngineDefinedField <number>
 --- how far the target needs to be before we start firing
----@field MaxRadius number
+---@field MaxRadius EngineDefinedField <number>
 --- the beam will cut off at this distance from the weapon
 ---@field MaximumBeamLength? number
 ---@field MetaImpactAmount any unused
 ---@field MetaImpactRadius any unused
 --- the minimum range we must be to fire at our target
----@field MinRadius number
+---@field MinRadius EngineDefinedField <number>
 --- The time that the muzzle will wait between playing the FxMuzzleFlash table and the creation of
 --- the projectile. Note: This will delay the firing of the projectile. So if you set the rate of
 --- fire to fire quickly, this will throttle it.
----@field MuzzleChargeDelay number
+---@field MuzzleChargeDelay EngineDefinedField <number>
 --- Time in between muzzles firing. Setting to 0 means all muzzles fire together. This time,
 --- multiplied by the number of muzzles minus 1, must not exceed the inverse of the rate of fire.
----@field MuzzleSalvoDelay number
+---@field MuzzleSalvoDelay EngineDefinedField <number>
 --- Number of times the muzzle will fire during a rack firing
----@field MuzzleSalvoSize number
+---@field MuzzleSalvoSize EngineDefinedField <number>
 --- Speed at which the projectile comes out of the muzzle. This speed is used in the ballistics
 --- calculations. If you weapon doesn't fire at its max radius, this may be too low.
 ---@field MuzzleChargeStart? number
 --- Determines which bone units are tractored to. Used by `ADFTractorClaw` (UAL0401 Galactic Colossus's tractor beam)
 ---@field MuzzleSpecial? number
 --- the exit velocity of the projectile once created at the muzzle of the barrel 
----@field MuzzleVelocity number
+---@field MuzzleVelocity EngineDefinedField <number>
 --- random variation in the weapon's muzzle velocity (gaussian)
----@field MuzzleVelocityRandom number
+---@field MuzzleVelocityRandom EngineDefinedField <number>
 --- Target distance at which the weapon will start reducing muzzle velocity to maintain a higher
 --- firing arc. This was put there so weapons that have a high muzzle velocity (because they have
 --- a huge range, like an artillery piece), wouldn't point right at something that's close,
 --- it'll slow down its shot to still have a nice arc to it.
----@field MuzzleVelocityReduceDistance number
+---@field MuzzleVelocityReduceDistance EngineDefinedField <number>
 --- if `NeedProp` is true then whenever the unit aquires a new target and is ready to attack it, it
 --- will first run the `OnGotTarget` script on the weapon
 ---@field NeedPrep? boolean
@@ -247,17 +247,17 @@
 --- targeting
 ---@field PrefersPrimaryWeaponTarget? boolean
 --- blueprint of the projectile to fire
----@field ProjectileId FileName
+---@field ProjectileId EngineDefinedField <FileName>
 --- Lifetime for projectile in seconds.
 --- If 0, the projectile will use the lifetime from its own blueprint.
----@field ProjectileLifetime number
+---@field ProjectileLifetime EngineDefinedField <number>
 --- Sets the lifetime for the projectile to use the lifetime equation of
 --- `ProjectileLifetimeUsesMultiplier * MaxRadius / MuzzleVelocity`
 ---@field ProjectileLifetimeUsesMultiplier? number
 --- list of weapon racks this weapon uses
----@field RackBones WeaponRacksBlueprint
+---@field RackBones EngineDefinedField <WeaponRacksBlueprint>
 --- if all racks fire simultaneously
----@field RackFireTogether boolean
+---@field RackFireTogether EngineDefinedField <boolean>
 --- Distance racks will recoil along the weapon's z-axis (local coords).
 --- `MuzzleSalvoDelay` cannot be 0, so that there's time to return the racks.
 ---@field RackRecoilDistance? number
@@ -269,15 +269,15 @@
 --- time before the racks start firing
 ---@field RackSalvoChargeTime? number
 --- if the racks immediately fire when done charging or if they wait until next `OnFire` event
----@field RackSalvoFiresAfterCharge boolean
+---@field RackSalvoFiresAfterCharge EngineDefinedField <boolean>
 --- time the racks will reload before starting its next charge/salve cycle
----@field RackSalvoReloadTime number
+---@field RackSalvoReloadTime EngineDefinedField <number>
 --- if all rack bones are "slaved" to the turret pitch bone
----@field RackSlavedToTurret boolean
+---@field RackSlavedToTurret EngineDefinedField <boolean>
 --- the range category this weapon satisfies
 ---@field RangeCategory? WeaponRangeCategory
 --- Rack firings per second. You can use decimals for fire rates that are longer than a second.
----@field RateOfFire number
+---@field RateOfFire EngineDefinedField <number>
 --- if this weapon will find new target on miss events
 ---@field ReTargetOnMiss? boolean
 --- if `true`, will set the orange work progress bar to display the reload progress of this weapon
@@ -300,17 +300,17 @@
 --- flag to specify to not make the weapon active if the primary weapon has a current target
 ---@field StopOnPrimaryWeaponBusy? boolean
 --- interval of time between looking for a target
----@field TargetCheckInterval number
+---@field TargetCheckInterval EngineDefinedField <number>
 --- issues a `ResetTarget` half way the firing sequence
----@field TargetResetWhenReady boolean
+---@field TargetResetWhenReady EngineDefinedField <boolean>
 --- table of category strings that define the targetting order of this weapon
----@field TargetPriorities UnparsedCategory[]
+---@field TargetPriorities EngineDefinedField <UnparsedCategory[]>
 --- comma separated list of category names that are always invalid targets
----@field TargetRestrictDisallow UnparsedCategory
+---@field TargetRestrictDisallow EngineDefinedField <UnparsedCategory>
 --- comma separated list of category names that are the only valid targets
----@field TargetRestrictOnlyAllow UnparsedCategory
+---@field TargetRestrictOnlyAllow EngineDefinedField <UnparsedCategory>
 --- the type of entity this unit can target
----@field TargetType WeaponTargetType
+---@field TargetType EngineDefinedField <WeaponTargetType>
 --- Lets the AI know that this weapon is one of two weapon definitions on a weapon bone that gets
 --- used when toggling between ground and anti-air. Which weapon is which is determined by which
 --- weapon has a `FireTargetLayerCapsTable` layer containing `"Air"`. The string should be the label
@@ -336,25 +336,25 @@
 --- If two manipulators are needed for this weapon. Used for bots with arms.
 ---@field TurretDualManipulators? boolean
 --- if this weapon has a turret. Defaults to false
----@field Turreted boolean
+---@field Turreted EngineDefinedField <boolean>
 --- the center angle for determining pitch, based off the rest pose of the model
----@field TurretPitch number
+---@field TurretPitch EngineDefinedField <number>
 --- the angle +/- off the pitch that is a valid angle to turn to
----@field TurretPitchRange number
+---@field TurretPitchRange EngineDefinedField <number>
 --- the speed at which the turret can pitch
----@field TurretPitchSpeed number
+---@field TurretPitchSpeed EngineDefinedField <number>
 --- the center angle for determining yaw, based off the rest pose of the model
----@field TurretYaw number
+---@field TurretYaw EngineDefinedField <number>
 --- the angle +/- off the yaw that is a valid angle to turn to
----@field TurretYawRange number
+---@field TurretYawRange EngineDefinedField <number>
 --- the speed at which the turret can turn in its yaw direction
----@field TurretYawSpeed number
+---@field TurretYawSpeed EngineDefinedField <number>
 --- the center angle for determining secondary yaw, based off the rest pose of the model
----@field TurretDualYaw number
+---@field TurretDualYaw EngineDefinedField <number>
 --- the angle +/- off the secondary yaw that is a valid angle to turn to
----@field TurretDualYawRange number
+---@field TurretDualYawRange EngineDefinedField <number>
 --- the speed at which the secondary turret can turn in its yaw direction
----@field TurretDualYawSpeed number
+---@field TurretDualYawSpeed EngineDefinedField <number>
 --- if this weapon uses the recent firing solution to create projectile instead of the
 --- aim bone transform when it fires.
 ---@field UseFiringSolutionInsteadOfAimBone? boolean
@@ -381,11 +381,11 @@
 ---@field YawOnlyOnTarget? boolean
 ---
 --- auto-generated by `unit.BlueprintId .. "-" .. <weapon index> .. "-" .. weapon.Label`
----@field BlueprintId BlueprintId
+---@field BlueprintId EngineDefinedField <BlueprintId>
 --- auto-generated from `MuzzleSalvoSize` to keep backwards compatibility
----@field ProjectilesPerOnFire number
+---@field ProjectilesPerOnFire EngineDefinedField <number>
 --- auto-generated to `1` to keep backwards compatibility
----@field RackSalvoSize number
+---@field RackSalvoSize EngineDefinedField <number>
 
 ---@class WeaponBlueprintFlare
 --- the category of projectiles this flare will attract

--- a/engine/User/CLobby.lua
+++ b/engine/User/CLobby.lua
@@ -43,8 +43,8 @@ local CLobby = {}
 ---@field Timeouts any          # Read by the engine to determine the behavior of time outs.
 ---@field CivilianAlliance any  # Read by the engine to determine the alliance towards civilians.
 ---@field GameSpeed any         # Read by the engine to determine the behavior of game speed (adjustments).
----@field Ratings table<string, number>
----@field Divisions table<string, string>
+---@field Ratings EngineDefinedField <table<string, number>>
+---@field Divisions EngineDefinedField <table<string, string>>
 
 ---@class UILobbyLaunchGameModsConfiguration
 ---@field name string           # Read by the engine, TODO
@@ -55,17 +55,17 @@ local CLobby = {}
 ---@field PlayerName string         # Read by the engine, TODO
 
 ---@class UILobbyLaunchPlayerConfiguration
----@field StartSpot number          # Read by Lua code to determine start locations
----@field Team number               # Read by Lua code to determine teams
----@field ArmyName string           # Read by the engine, TODO
----@field PlayerName string         # Read by the engine, TODO
----@field Civilian boolean          # Read by the engine, TODO
----@field Human boolean             # Read by the engine, TODO
----@field AIPersonality string      # Read by the engine iff Human is false
----@field ArmyColor number          # Read by the engine, is mapped to a color by reading the values of `lua\GameColors.lua`.
----@field PlayerColor number        # Read by the engine, is mapped to a color by reading the values of `lua\GameColors.lua`
----@field Faction number            # Read by the engine to determine the faction of the player.
----@field OwnerID UILobbyPeerId   # Read by the engine, TODO
+---@field StartSpot EngineDefinedField <number>          # Read by Lua code to determine start locations
+---@field Team EngineDefinedField <number>               # Read by Lua code to determine teams
+---@field ArmyName EngineDefinedField <string>           # Read by the engine, TODO
+---@field PlayerName EngineDefinedField <string>         # Read by the engine, TODO
+---@field Civilian EngineDefinedField <boolean>          # Read by the engine, TODO
+---@field Human EngineDefinedField <boolean>             # Read by the engine, TODO
+---@field AIPersonality EngineDefinedField <string>      # Read by the engine iff Human is false
+---@field ArmyColor EngineDefinedField <number>          # Read by the engine, is mapped to a color by reading the values of `lua\GameColors.lua`.
+---@field PlayerColor EngineDefinedField <number>        # Read by the engine, is mapped to a color by reading the values of `lua\GameColors.lua`
+---@field Faction EngineDefinedField <number>            # Read by the engine to determine the faction of the player.
+---@field OwnerID EngineDefinedField <UILobbyPeerId>   # Read by the engine, TODO
 
 --- All the following fields are read by the engine upon launching the lobby.
 ---@class UILobbyLaunchConfiguration

--- a/engine/User/CMauiControl.lua
+++ b/engine/User/CMauiControl.lua
@@ -1,13 +1,13 @@
 ---@meta
 
 ---@class moho.control_methods : Destroyable
----@field Left LazyVar<number>
----@field Width LazyVar<number>
----@field Right LazyVar<number>
----@field Top LazyVar<number>
----@field Height LazyVar<number>
----@field Bottom LazyVar<number>
----@field Depth LazyVar<number>
+---@field Left EngineDefinedField <LazyVar<number>>
+---@field Width EngineDefinedField <LazyVar<number>>
+---@field Right EngineDefinedField <LazyVar<number>>
+---@field Top EngineDefinedField <LazyVar<number>>
+---@field Height EngineDefinedField <LazyVar<number>>
+---@field Bottom EngineDefinedField <LazyVar<number>>
+---@field Depth EngineDefinedField <LazyVar<number>>
 local CMauiControl = {}
 
 ---

--- a/lua/AI/AIBaseTemplates/RushMainNaval.lua
+++ b/lua/AI/AIBaseTemplates/RushMainNaval.lua
@@ -139,6 +139,7 @@ BaseBuilderTemplate {
     ExpansionFunction = function(aiBrain, location, markerType)
         return 0
     end,
+    
     FirstBaseFunction = function(aiBrain)
         local mapSizeX, mapSizeZ = GetMapSize()
         local startX, startZ = aiBrain:GetArmyStartPos()

--- a/lua/AI/AIBuilders/AILandAttackBuilders.lua
+++ b/lua/AI/AIBuilders/AILandAttackBuilders.lua
@@ -25,6 +25,9 @@ local PlatoonFile = '/lua/platoon.lua'
 
 ---@alias BuilderGroupsLandAttack 'T1LandFactoryBuilders' | 'T1LandAA' | 'T1ReactionDF' | 'T2LandFactoryBuilders' | 'T2LandFactoryAmphibiousBuilders' | 'T2ReactionDF' | 'T2LandAA' | 'T3LandFactoryBuilders' | 'T3LandResponseBuilders' | 'T3ReactionDF' | 'UnitCapLandAttackFormBuilders' | 'FrequentLandAttackFormBuilders' | 'Artillery Attack' | 'FearlessFrequentLandAttackFormBuilders' | 'BigLandAttackFormBuilders' | 'MassHunterLandFormBuilders' | 'MiscLandFormBuilders'
 
+---@param aiBrain? AIBrain
+---@param locationType LocationType
+---@param targetNumber number
 function LandAttackCondition(aiBrain, locationType, targetNumber)
     local pool = aiBrain:GetPlatoonUniquelyNamed('ArmyPool')
     local engineerManager = aiBrain.BuilderManagers[locationType].EngineerManager

--- a/lua/AI/OpAI/BaseManager.lua
+++ b/lua/AI/OpAI/BaseManager.lua
@@ -38,13 +38,13 @@
 ---@field [2] FunctionName
 
 ---@class PlatoonData
----@field TransportReturn Marker                # Location for transports to return to
----@field PatrolChains MarkerChain[]            # Selection of patrol chains to guide the constructed units
----@field PatrolChain MarkerChain               # Patrol chain to guide the construced units
----@field AttackChain MarkerChain               # Attack chain to guide the constructed units
----@field LandingChain MarkerChain              # Landing chain to guide the transports carrying the constructed units
----@field Area Area                             # An area, use depends on master platoon function
----@field Location Marker                       # A location, use depends on master platoon function
+---@field TransportReturn EngineDefinedField <Marker>                # Location for transports to return to
+---@field PatrolChains EngineDefinedField <MarkerChain[]>            # Selection of patrol chains to guide the constructed units
+---@field PatrolChain EngineDefinedField <MarkerChain>               # Patrol chain to guide the construced units
+---@field AttackChain EngineDefinedField <MarkerChain>               # Attack chain to guide the constructed units
+---@field LandingChain EngineDefinedField <MarkerChain>              # Landing chain to guide the transports carrying the constructed units
+---@field Area EngineDefinedField <Area>                             # An area, use depends on master platoon function
+---@field Location EngineDefinedField <Marker>                       # A location, use depends on master platoon function
 
 ---@class AddOpAIData
 ---@field MasterPlatoonFunction FileFunctionRef     # Behavior of instances upon completion

--- a/lua/TerrainTypes.lua
+++ b/lua/TerrainTypes.lua
@@ -131,16 +131,16 @@
 ---@field TypeCode integer
 ---@field Color Color
 ---@field Description string
----@field Style TerrainStyle
----@field Slippery number
----@field Bumpiness number
----@field Blocking boolean
----@field FXIdle table<Layer, table<IdleEffectType, FileName[]>>
----@field FXImpact table<ImpactType, table<ImpactEffectType, FileName[]>>
----@field FXLayerChange table<LayerChangeType, table<LayerChangeEffectType, FileName[]>>
----@field FXMotionChange table<MotionChangeType, table<MotionChangeEffectType, FileName[]>>
----@field FXMovement table<Layer, table<MovementEffectType, FileName[]>>
----@field FXOther table<Layer, table<OtherEffectType, FileName[]>>
+---@field Style EngineDefinedField <TerrainStyle>
+---@field Slippery EngineDefinedField <number>
+---@field Bumpiness EngineDefinedField <number>
+---@field Blocking EngineDefinedField <boolean>
+---@field FXIdle EngineDefinedField <table<Layer, table<IdleEffectType, FileName[]>>>
+---@field FXImpact EngineDefinedField <table<ImpactType, table<ImpactEffectType, FileName[]>>>
+---@field FXLayerChange EngineDefinedField <table<LayerChangeType, table<LayerChangeEffectType, FileName[]>>>
+---@field FXMotionChange EngineDefinedField <table<MotionChangeType, table<MotionChangeEffectType, FileName[]>>>
+---@field FXMovement EngineDefinedField <table<Layer, table<MovementEffectType, FileName[]>>>
+---@field FXOther EngineDefinedField <table<Layer, table<OtherEffectType, FileName[]>>>
 ---@field Treads? TerrainTreadType
 
 local EmitterBasePath = '/effects/emitters/'

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -1219,7 +1219,7 @@ AIBrain = Class(FactoryManagerBrainComponent, StatManagerBrainComponent, JammerM
     -------------------------------------------------------------------------------
 }
 
----#region backwards compatibility
+--#region backwards compatibility
 
 local CalculateBrainScore = import("/lua/sim/score.lua").CalculateBrainScore
 local TransferUnitsOwnership = SimUtils.TransferUnitsOwnership

--- a/lua/aibrains/managers/base-manager.lua
+++ b/lua/aibrains/managers/base-manager.lua
@@ -43,9 +43,9 @@ local TableSort = table.sort
 --- | string
 
 ---@class AIBaseDebugInfo
----@field Position Vector
----@field Layer NavLayers
----@field Managers { EngineerManagerDebugInfo: AIEngineerManagerDebugInfo, StructureManagerDebugInfo: AIStructureManagerDebugInfo, FactoryManagerDebugInfo: AIFactoryManagerDebugInfo }
+---@field Position EngineDefinedField <Vector>
+---@field Layer EngineDefinedField <NavLayers>
+---@field Managers EngineDefinedField <{ EngineerManagerDebugInfo: AIEngineerManagerDebugInfo, StructureManagerDebugInfo: AIStructureManagerDebugInfo, FactoryManagerDebugInfo: AIFactoryManagerDebugInfo }>
 
 ---@class AIBase
 ---@field Brain AIBrain

--- a/lua/aibrains/managers/structure-manager.lua
+++ b/lua/aibrains/managers/structure-manager.lua
@@ -25,9 +25,9 @@ local TableGetSize = table.getsize
 local WeakValueTable = { __mode = 'v' }
 
 ---@class AIStructureManagerDebugInfo
----@field Structures { TECH1: EntityId[], TECH2: EntityId[], TECH3: EntityId[], EXPERIMENTAL: EntityId[] }
----@field StructuresBeingBuilt { TECH1: EntityId[], TECH2: EntityId[], TECH3: EntityId[], EXPERIMENTAL: EntityId[] }
----@field GeneratedThreat { Surface: number, Air: number, Economy: number, Sub: number }
+---@field Structures EngineDefinedField <{ TECH1: EntityId[], TECH2: EntityId[], TECH3: EntityId[], EXPERIMENTAL: EntityId[] }>
+---@field StructuresBeingBuilt EngineDefinedField <{ TECH1: EntityId[], TECH2: EntityId[], TECH3: EntityId[], EXPERIMENTAL: EntityId[] }>
+---@field GeneratedThreat EngineDefinedField <{ Surface: number, Air: number, Economy: number, Sub: number }>
 
 ---@class AIStructureManagerReferences
 ---@field TECH1 table<EntityId, Unit>

--- a/lua/aibrains/platoons/platoon-base.lua
+++ b/lua/aibrains/platoons/platoon-base.lua
@@ -7,10 +7,10 @@ local IsDestroyed = IsDestroyed
 local TableGetn = table.getn
 
 ---@class AIPlatoonDebugInfo
----@field EntityId EntityId
----@field BlueprintId BlueprintId
----@field Position Vector
----@field PlatoonInfo { DebugMessages: string[], PlatoonName: string, StateName: string } 
+---@field EntityId EngineDefinedField <EntityId>
+---@field BlueprintId EngineDefinedField <BlueprintId>
+---@field Position EngineDefinedField <Vector>
+---@field PlatoonInfo EngineDefinedField <{ DebugMessages: string[], PlatoonName: string, StateName: string }>
 
 ---@class AIPlatoonState : State
 ---@field StateName string

--- a/lua/aibrains/tasks/task.lua
+++ b/lua/aibrains/tasks/task.lua
@@ -45,7 +45,7 @@ local TableGetn = table.getn
 ---@class AITaskTemplate
 ---@field Identifier string             # Unique identifier for a task.
 ---
----@field BuildCategory EntityCategory         # Used when searching for a task and when executing a task. Defines the categories of the unit that we're trying to build
+---@field BuildCategory EngineDefinedField <EntityCategory>         # Used when searching for a task and when executing a task. Defines the categories of the unit that we're trying to build
 ---@field DefaultDistance? number       # Used when searching for a task. If set, any unit that is within this distance to the base can accept this task.
 ---@field DefaultPriority number        # Used when creating or evaluating the task.
 ---@field PreferredChunk? string        # Used when executing a task. Specifically used by engineers that are looking for a place to build

--- a/lua/aibrains/templates/base/base-template.lua
+++ b/lua/aibrains/templates/base/base-template.lua
@@ -1,8 +1,8 @@
 ---@declare-global
 
 ---@class AIBaseTemplateManager
----@field BuilderGroupTemplates AIBuilderGroupTemplate[]                # List of names of builder groups
----@field BuilderGroupTemplatesNonCheating AIBuilderGroupTemplate[]     # List of names of builder groups when AI does not have `SallyShears` enabled
+---@field BuilderGroupTemplates EngineDefinedField <AIBuilderGroupTemplate[]>                # List of names of builder groups
+---@field BuilderGroupTemplatesNonCheating EngineDefinedField <AIBuilderGroupTemplate[]>     # List of names of builder groups when AI does not have `SallyShears` enabled
 
 ---@class AIBaseTemplate
 ---@field BaseTemplateName string   # Unique identifier to reference the base template

--- a/lua/aibrains/templates/builder-groups/builder-group-template.lua
+++ b/lua/aibrains/templates/builder-groups/builder-group-template.lua
@@ -4,7 +4,7 @@
 
 ---@class AIBuilderGroupTemplate
 ---@field BuilderGroupName string
----@field BuilderGroupType string
+---@field BuilderGroupType EngineDefinedField <string>
 ---@field BuilderTemplates AIBuilderTemplate[]
 
 --- Register a builder group, or override an existing builder group

--- a/lua/aibrains/templates/builders/builder-template.lua
+++ b/lua/aibrains/templates/builders/builder-template.lua
@@ -8,8 +8,8 @@
 
 ---@class AIBuilderTemplateCondition
 ---@field [1] FileReference         # File reference
----@field [2] FunctionReference     # Function reference
----@field [3] FunctionParameters    # Function parameters
+---@field [2] EngineDefinedField <FunctionReference>     # Function reference
+---@field [3] EngineDefinedField <FunctionParameters>    # Function parameters
 
 ---@class AIBuilderCondition
 ---@field [1] function 
@@ -17,20 +17,20 @@
 
 ---@class AIBuilderData
 --- Used by the structure manager. Indicates to use the `UpgradeTo` field of the blueprint of the structure
----@field UseUpgradeToBlueprintField boolean
+---@field UseUpgradeToBlueprintField EngineDefinedField <boolean>
 --- used by the structure manager. Indicates a specific blueprint to upgrade to, the second character is replaced with the faction of the structure: `uab0302` would become `ueb0302` for the UEF tech 3 land factory
----@field UpgradeToFactionReplace string
+---@field UpgradeToFactionReplace EngineDefinedField <string>
 --- categories used for various tasks
----@field Categories EntityCategory
+---@field Categories EngineDefinedField <EntityCategory>
 
 ---@class AIBuilderTemplate
 ---@field BuilderConditions AIBuilderTemplateCondition[]
 ---@field BuilderData AIBuilderData
----@field BuilderDisabled boolean
----@field BuilderInstanceCount number
----@field BuilderInstances table
+---@field BuilderDisabled EngineDefinedField <boolean>
+---@field BuilderInstanceCount EngineDefinedField <number>
+---@field BuilderInstances EngineDefinedField <table>
 ---@field BuilderName string
----@field BuilderType string                        # Used to filter builders for a given unit
+---@field BuilderType EngineDefinedField <string>                        # Used to filter builders for a given unit
 ---@field BuilderFaction FactionCategory | nil    # Used to quickly reject builders for a given unit
 ---@field BuilderLayer LayerCategory | nil         # Used to quickly reject builders for a given unit
 ---@field BuilderTech TechCategory | nil           # Used to quickly reject builders for a given unit

--- a/lua/defaultcomponents.lua
+++ b/lua/defaultcomponents.lua
@@ -597,9 +597,9 @@ local VeterancyRegenBuffs = {
 }
 
 ---@class VeterancyComponent
----@field VetDamage table<EntityId, number>
----@field VetDamageTaken number
----@field VetInstigators table<EntityId, Unit>
+---@field VetDamage EngineDefinedField <table<EntityId, number>>
+---@field VetDamageTaken EngineDefinedField <number>
+---@field VetInstigators EngineDefinedField <table<EntityId, Unit>>
 ---@field VetExperience? number
 ---@field VetLevel? number 
 ---@field VetMassKillCredit? number -- bookkeeping number available to the player via stat

--- a/lua/maui/checkbox.lua
+++ b/lua/maui/checkbox.lua
@@ -5,13 +5,13 @@ local Dragger = import("/lua/maui/dragger.lua").Dragger
 ---@alias MauiCheckboxState "normal" | "over" | "disabled"
 
 ---@class MauiCheckboxTexture
----@field checked FileName
----@field unchecked FileName
+---@field checked EngineDefinedField <FileName>
+---@field unchecked EngineDefinedField <FileName>
 
 ---@class MauiCheckboxStateTextures
----@field normal MauiCheckboxTexture
----@field over MauiCheckboxTexture
----@field disabled MauiCheckboxTexture
+---@field normal EngineDefinedField <MauiCheckboxTexture>
+---@field over EngineDefinedField <MauiCheckboxTexture>
+---@field disabled EngineDefinedField <MauiCheckboxTexture>
 
 ---@alias CheckState "checked" | "unchecked"
 

--- a/lua/maui/control.lua
+++ b/lua/maui/control.lua
@@ -26,7 +26,7 @@
     -- Dump()
 
 ---@class Control : moho.control_methods
----@field _isDisabled boolean
+---@field _isDisabled  EngineDefinedField <boolean>
 Control = ClassUI(moho.control_methods) {
     --- Resets the control's layout to the defaults, in this case
     --- makes a circular dependency where you must have at least 4 defined.

--- a/lua/shared/ChatPayload.lua
+++ b/lua/shared/ChatPayload.lua
@@ -25,7 +25,7 @@
 ---@field location?   table                # lightweight location hint — see `UIChatEntryLocation` for the inner shape
 ---@field Args?       any[]                # `LOCF`-style format args spread alongside `text` on render
 ---@field Id?         string               # sender-stamped near-unique id; dedupes the two delivery paths
----@field From        number               # sim-stamped trusted sender army index — written by the relay before broadcast
+---@field From        EngineDefinedField <number>               # sim-stamped trusted sender army index — written by the relay before broadcast
 
 --- Maximum UTF-8 character length for a chat message body. The UI edit box
 --- enforces this on input; the sim relay and the receive path gate on the

--- a/lua/shared/NavGenerator.lua
+++ b/lua/shared/NavGenerator.lua
@@ -15,30 +15,30 @@ LayerColors = {
 }
 
 ---@class NavDebugGetLabelState
----@field Position Vector 
----@field Layer NavLayers
+---@field Position EngineDefinedField <Vector> 
+---@field Layer EngineDefinedField <NavLayers>
 
 ---@class NavDebugGetLabelMetadataState
 ---@field Id number
 
 ---@class NavDebugPathToState
----@field Origin Vector 
----@field Destination Vector 
----@field Layer NavLayers
+---@field Origin EngineDefinedField <Vector> 
+---@field Destination EngineDefinedField <Vector> 
+---@field Layer EngineDefinedField <NavLayers>
 
 ---@class NavDebugPathToStateWithThreatThreshold
----@field Origin Vector 
----@field Destination Vector 
----@field Layer NavLayers
----@field Radius number
----@field Threshold number
----@field ThreatFunctionName AIThreatFunctionNames
----@field Army Army
+---@field Origin EngineDefinedField <Vector> 
+---@field Destination EngineDefinedField <Vector> 
+---@field Layer EngineDefinedField <NavLayers>
+---@field Radius EngineDefinedField <number>
+---@field Threshold EngineDefinedField <number>
+---@field ThreatFunctionName EngineDefinedField <AIThreatFunctionNames>
+---@field Army EngineDefinedField <Army>
 
 ---@class NavDebugCanPathToState
----@field Origin Vector 
----@field Destination Vector 
----@field Layer NavLayers
+---@field Origin EngineDefinedField <Vector> 
+---@field Destination EngineDefinedField <Vector> 
+---@field Layer EngineDefinedField <NavLayers>
 
 ---@class NavLayerDataInstance
 ---@field Subdivisions number

--- a/lua/shared/Profiler.lua
+++ b/lua/shared/Profiler.lua
@@ -6,10 +6,10 @@
 ---@alias ProfilerSource "C" | "Lua" | "main" | "unknown"
 
 ---@class ProfilerData
----@field C ProfilerSourceData
----@field Lua ProfilerSourceData
----@field main ProfilerSourceData
----@field unknown ProfilerSourceData
+---@field C EngineDefinedField <ProfilerSourceData>
+---@field Lua EngineDefinedField <ProfilerSourceData>
+---@field main EngineDefinedField <ProfilerSourceData>
+---@field unknown EngineDefinedField <ProfilerSourceData>
 
 ---@alias ProfilerScope "field" | "global" | "local" | "method" | "other" | "upvalue"
 

--- a/lua/sim/BuilderManager.lua
+++ b/lua/sim/BuilderManager.lua
@@ -24,8 +24,8 @@ local function BuilderSortLambda(a, b)
 end
 
 ---@class AIBuilderData
----@field Builders Builder[]
----@field NeedSort boolean
+---@field Builders EngineDefinedField <Builder[]>
+---@field NeedSort EngineDefinedField <boolean>
 
 --- An abstract class of the various managers. Introduces the logic to maintain
 --- and find builders as the base is trying to figure out what to do

--- a/lua/sim/MarkerUtilities.lua
+++ b/lua/sim/MarkerUtilities.lua
@@ -26,24 +26,24 @@ local TableDeepCopy = table.deepcopy
 ---@alias MarkerType 'Mass' | 'Hydrocarbon' | 'Spawn' | 'Start Location' | 'Air Path Node' | 'Land Path Node' | 'Water Path Node' | 'Ampibious Path Node' | 'Transport Marker' | 'Naval Area' | 'Naval Link' | 'Rally Point' | 'Large Expansion Area' | 'Expansion Area' | 'Protected Experimental Construction'
 
 ---@class MarkerDataLegacy
----@field size number           # Legacy name used by the GPG editor, same as `Size`
----@field resource boolean      # Legacy name used by the GPG editor, same as `Resource`
----@field type string           # Legacy name used by the GPG editor, same as `Type`
----@field orientation Vector    # Legacy name used by the GPG editor, same as `Orientation`
----@field position Vector       # Legacy name used by the GPG editor, same as `Position`
+---@field size EngineDefinedField <number>           # Legacy name used by the GPG editor, same as `Size`
+---@field resource EngineDefinedField <boolean>      # Legacy name used by the GPG editor, same as `Resource`
+---@field type EngineDefinedField <string>           # Legacy name used by the GPG editor, same as `Type`
+---@field orientation EngineDefinedField <Vector>    # Legacy name used by the GPG editor, same as `Orientation`
+---@field position EngineDefinedField <Vector>       # Legacy name used by the GPG editor, same as `Position`
 ---@field color? Color          # Legacy name used by the GPG editor, same as `Color`
 ---@field adjacentTo? string    # Legacy name used by the Ozonex editor
 
 ---@class MarkerDataModSupport
----@field Size number           # Field exists for mod support, same as `size`
----@field Resource boolean      # Field exists for mod support, same as `resource`
----@field Type string           # Field exists for mod support, same as `type`
----@field Orientation Vector    # Field exists for mod support, same as `orientation`
----@field Position Vector       # Field exists for mod support, same as `position`
+---@field Size EngineDefinedField <number>           # Field exists for mod support, same as `size`
+---@field Resource EngineDefinedField <boolean>      # Field exists for mod support, same as `resource`
+---@field Type EngineDefinedField <string>           # Field exists for mod support, same as `type`
+---@field Orientation EngineDefinedField <Vector>    # Field exists for mod support, same as `orientation`
+---@field Position EngineDefinedField <Vector>       # Field exists for mod support, same as `position`
 ---@field Color? Color          # Field exists for mod support, same as `color`
 
 ---@class MarkerData : MarkerDataLegacy, MarkerDataModSupport
----@field Name string               # Unique name for marker
+---@field Name EngineDefinedField <string>               # Unique name for marker
 ---@field NavLayer? NavLayers       # Navigational layer that this marker is on, only defined for resources
 ---@field NavLabel? number | nil    # Navigational label of the graph this marker is on, only defined for resources and when AIs are in-game
 
@@ -53,7 +53,7 @@ local TableDeepCopy = table.deepcopy
 -- ---@field Island MarkerIsland
 
 ---@class MarkerExpansion : MarkerData
----@field NavLabel number
+---@field NavLabel EngineDefinedField <number>
 -- ---@field Island MarkerIsland
 ---@field Extractors MarkerResource[]
 -- ---@field Hydrocarbons MarkerResource[]

--- a/lua/sim/NavGenerator.lua
+++ b/lua/sim/NavGenerator.lua
@@ -406,7 +406,7 @@ end
 ---@field pz number                 # z-coordinate of center in world space
 
 ---@class NavSection : NavPathingData
----@field Area number
+---@field Area EngineDefinedField <number>
 ---@field Center Vector
 ---@field Identifier NavSectionIdentifier
 ---@field Label NavLabelIdentifier

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -99,8 +99,8 @@ SyncMeta = {
 ---@field AdjRoFMod? number
 
 ---@class AIUnitProperties
----@field AIPlatoonReference AIPlatoon
----@field AIBaseManager LocationType
+---@field AIPlatoonReference EngineDefinedField <AIPlatoon>
+---@field AIBaseManager EngineDefinedField <LocationType>
 ---@field ForkedEngineerTask? thread    # used by the engineer manager
 ---@field DesiresAssist? boolean         # used by the engineer manager
 ---@field NumAssistees? number           # used by the engineer manager
@@ -112,8 +112,8 @@ SyncMeta = {
 ---@field Combat? boolean
 
 ---@class CampaignAIUnitProperties
----@field BaseName string Name of the BaseManager the unit belongs to
----@field UnitName string Name of the unit from the map editor (_save.lua)
+---@field BaseName EngineDefinedField <string> Name of the BaseManager the unit belongs to
+---@field UnitName EngineDefinedField <string> Name of the unit from the map editor (_save.lua)
 ---@field SetToUpgrade boolean|nil Unit marked by the BaseManager for upgrade
 ---@field CDRData table|nil Copy of the platoon data when the BaseManager upgrades the commander
 
@@ -127,43 +127,43 @@ local cUnitGetBuildRate = cUnit.GetBuildRate
 ---@class Unit : moho.unit_methods, InternalObject, IntelComponent, VeterancyComponent, AIUnitProperties, CampaignAIUnitProperties, UnitBuffFields, DebugUnitComponent, FastDecayComponent
 ---@field CDRHome? LocationType
 ---@field AIManagerIdentifier? string
----@field Repairers table<EntityId, Unit>
----@field Brain AIBrain
+---@field Repairers EngineDefinedField <table<EntityId, Unit>>
+---@field Brain EngineDefinedField <AIBrain>
 ---@field buildBots? Unit[]
----@field Blueprint UnitBlueprint
----@field BuildEffectsBag TrashBag
+---@field Blueprint EngineDefinedField <UnitBlueprint>
+---@field BuildEffectsBag EngineDefinedField <TrashBag>
 ---@field BuildArmManipulator? moho.BuilderArmManipulator
----@field Trash TrashBag
----@field Layer Layer
----@field Army Army
+---@field Trash EngineDefinedField <TrashBag>
+---@field Layer EngineDefinedField <Layer>
+---@field Army EngineDefinedField <Army>
 ---@field Dead? boolean
----@field UnitId UnitId
----@field EntityId EntityId
----@field EventCallbacks table<string, function[]>
----@field Buffs UnitBuffsTable
+---@field UnitId EngineDefinedField <UnitId>
+---@field EntityId EngineDefinedField <EntityId>
+---@field EventCallbacks EngineDefinedField <table<string, function[]>>
+---@field Buffs EngineDefinedField <UnitBuffsTable>
 ---@field EngineFlags? table<string, any>
----@field TerrainType TerrainType
+---@field TerrainType EngineDefinedField <TerrainType>
 ---@field EngineCommandCap? table<string, boolean>
 ---@field UnitBeingBuilt Unit?
----@field UnitBuildOrder string
+---@field UnitBuildOrder EngineDefinedField <string>
 ---@field MyShield Shield?
 ---@field EntityBeingReclaimed Unit | Prop | nil
 ---@field SoundEntity? Unit | Entity
 ---@field AutoModeEnabled? boolean
----@field OnBeingBuiltEffectsBag TrashBag
----@field IdleEffectsBag TrashBag
+---@field OnBeingBuiltEffectsBag EngineDefinedField <TrashBag>
+---@field IdleEffectsBag EngineDefinedField <TrashBag>
 ---@field SiloWeapon? Weapon
 ---@field SiloProjectile? ProjectileBlueprint
 ---@field ReclaimTimeMultiplier? number
 ---@field CaptureTimeMultiplier? number
 ---@field PlatoonHandle? Platoon
 ---@field tickIssuedShieldRepair number? # Used by shields to keep track of when this unit's guards were ordered to start shield repair instantly
----@field Sync { id: string, army: Army } # Sync table replicated to the global sync table as to be copied to the user layer at sync time.
+---@field Sync EngineDefinedField <{ id: string, army: Army }> # Sync table replicated to the global sync table as to be copied to the user layer at sync time.
 ---@field ignoreDetectionFrom table<Army, true>? # Armies being given free vision to reveal beams hitting targets
 ---@field reallyDetectedBy table<Army, true>?    # Armies that detected the unit without free vision and don't need intel flushed when beam weapons stop hitting
----@field Weapons table<string, Weapon> # string is weapon Label
----@field WeaponInstances Weapon[]
----@field WeaponCount number
+---@field Weapons EngineDefinedField <table<string, Weapon>> # string is weapon Label
+---@field WeaponInstances EngineDefinedField <Weapon[]>
+---@field WeaponCount EngineDefinedField <number>
 ---@field CaptureProgress? number # Keeps track of capture progress to prevent sharing units being captured and to sync capture work progress bars
 ---@field oldowner? Army # After a unit is transferred, keeps track of the original Army to kill shared units when needed.
 ---@field TransferUpgradeProgress? boolean # Keeps track of upgrades for unit transfer

--- a/lua/sim/commands/shared.lua
+++ b/lua/sim/commands/shared.lua
@@ -64,9 +64,9 @@
 ---@class DistributeOrderInfo
 ---@field Callback? fun(units: Unit[], target: Vector | Entity, arg3?: any, arg4?: any): boolean
 ---@field Type DistributeOrderInfoCommandName   # Describes the intended order, useful for debugging
----@field BatchOrders boolean                   # When set, assigns orders to groups of units
----@field FullRedundancy boolean                # When set, attempts to add full redundancy when reasonable by assigning multiple orders to each group
----@field Redundancy number                     # When set, assigns orders to individual units. Number of orders assigned is equal to the redundancy factor
+---@field BatchOrders EngineDefinedField <boolean>                   # When set, assigns orders to groups of units
+---@field FullRedundancy EngineDefinedField <boolean>                # When set, attempts to add full redundancy when reasonable by assigning multiple orders to each group
+---@field Redundancy EngineDefinedField <number>                     # When set, assigns orders to individual units. Number of orders assigned is equal to the redundancy factor
 
 -- upvalue scope for performance
 local IssueNuke = IssueNuke

--- a/lua/sim/units/uef/TPodTowerUnit.lua
+++ b/lua/sim/units/uef/TPodTowerUnit.lua
@@ -23,12 +23,12 @@
 local TStructureUnit = import('/lua/terranunits.lua').TStructureUnit
 
 ---@class PodDataEntry
----@field PodHandle XEA3204
----@field PodUnitID "XEA3204" # Determined in pod tower's blueprint's `Economy.EngineeringPods`
----@field PodName string # Determined in pod tower's blueprint's `Economy.EngineeringPods`
----@field Active boolean
----@field PodAttachpoint Bone # Determined in pod tower's blueprint's `Economy.EngineeringPods`
----@field CreateWithUnit boolean # Determined in pod tower's blueprint's `Economy.EngineeringPods`
+---@field PodHandle EngineDefinedField <XEA3204>
+---@field PodUnitID EngineDefinedField <"XEA3204"> # Determined in pod tower's blueprint's `Economy.EngineeringPods`
+---@field PodName EngineDefinedField <string> # Determined in pod tower's blueprint's `Economy.EngineeringPods`
+---@field Active EngineDefinedField <boolean>
+---@field PodAttachpoint EngineDefinedField <Bone> # Determined in pod tower's blueprint's `Economy.EngineeringPods`
+---@field CreateWithUnit EngineDefinedField <boolean> # Determined in pod tower's blueprint's `Economy.EngineeringPods`
 
 ---@class TPodTowerUnit : TStructureUnit
 ---@field PodData table<string, PodDataEntry>

--- a/lua/sim/weapon.lua
+++ b/lua/sim/weapon.lua
@@ -20,20 +20,20 @@ local DebugWeaponComponent = import("/lua/sim/weapons/components/debugweaponcomp
 --- Table of damage information passed from the weapon to the projectile
 --- Can be assigned as a meta table to the projectile's damage table to reduce memory usage for unchanged values
 ---@class WeaponDamageTable
----@field DamageToShields number        # weaponBlueprint.DamageToShields
----@field InitialDamageAmount number    # weaponBlueprint.InitialDamage or 0
----@field DamageRadius number           # weaponBlueprint.DamageRadius + Weapon.DamageRadiusMod
----@field DamageAmount number           # weaponBlueprint.Damage + Weapon.DamageMod
----@field DamageType DamageType         # weaponBlueprint.DamageType
----@field DamageFriendly boolean        # weaponBlueprint.DamageFriendly or true
----@field CollideFriendly boolean       # weaponBlueprint.CollideFriendly or false
----@field DoTTime number                # weaponBlueprint.DoTTime
----@field DoTPulses number              # weaponBlueprint.DoTPulses
+---@field DamageToShields EngineDefinedField <number>        # weaponBlueprint.DamageToShields
+---@field InitialDamageAmount EngineDefinedField <number>    # weaponBlueprint.InitialDamage or 0
+---@field DamageRadius EngineDefinedField <number>           # weaponBlueprint.DamageRadius + Weapon.DamageRadiusMod
+---@field DamageAmount EngineDefinedField <number>           # weaponBlueprint.Damage + Weapon.DamageMod
+---@field DamageType EngineDefinedField <DamageType>         # weaponBlueprint.DamageType
+---@field DamageFriendly EngineDefinedField <boolean>        # weaponBlueprint.DamageFriendly or true
+---@field CollideFriendly EngineDefinedField <boolean>       # weaponBlueprint.CollideFriendly or false
+---@field DoTTime EngineDefinedField <number>                # weaponBlueprint.DoTTime
+---@field DoTPulses EngineDefinedField <number>              # weaponBlueprint.DoTPulses
 ---@field MetaImpactAmount any          # weaponBlueprint.MetaImpactAmount
 ---@field MetaImpactRadius any          # weaponBlueprint.MetaImpactRadius
----@field ArtilleryShieldBlocks boolean # weaponBlueprint.ArtilleryShieldBlocks
----@field Buffs BlueprintBuff[]         # Active buffs for the weapon
----@field __index WeaponDamageTable
+---@field ArtilleryShieldBlocks EngineDefinedField <boolean> # weaponBlueprint.ArtilleryShieldBlocks
+---@field Buffs EngineDefinedField <BlueprintBuff[]>         # Active buffs for the weapon
+---@field __index EngineDefinedField <WeaponDamageTable>
 
 ---@return EntityCategory[]
 local function ParsePriorities()

--- a/lua/system/GlobalBaseTemplate.lua
+++ b/lua/system/GlobalBaseTemplate.lua
@@ -24,16 +24,16 @@
 
 ---@class BaseBuilderTemplateSettings
 ---@field FactoryCount BaseBuilderTemplateFactoryCount
----@field EngineersCount BaseBuilderTemplateEngineerCount
+---@field EngineersCount EngineDefinedField <BaseBuilderTemplateEngineerCount>
 ---@field MassToFactoryValues BaseBuilderTemplateMassToFactoryValues
 
 ---@class BaseBuilderTemplateSpec
 ---@field BaseTemplateName BaseBuilderTemplateNames
 ---@field Builders table<BuilderGroupNames>
----@field NonCheatBuilders table<BuilderGroupNames>
+---@field NonCheatBuilders EngineDefinedField <table<BuilderGroupNames>>
 ---@field BaseSettings BaseBuilderTemplateSettings
 ---@field ExpansionFunction fun(aiBrain: AIBrain, location: Position, markerType: string)
----@field FirstBaseFunction fun(aiBrain: AIBrain)?
+---@field FirstBaseFunction? fun(aiBrain: AIBrain) : number, string
 
 -- Global list of all BaseBuilderTemplates found in the system.
 ---@type table<string, BaseBuilderTemplateSpec>
@@ -41,7 +41,6 @@ BaseBuilderTemplates = {}
 
 --- Register a base builder template, or override an existing base builder template
 ---@param spec BaseBuilderTemplateSpec
----@return string
 BaseBuilderTemplate = function(spec)
 
     -- it should be a table

--- a/lua/system/GlobalBuilderTemplate.lua
+++ b/lua/system/GlobalBuilderTemplate.lua
@@ -26,11 +26,11 @@
 ---@class BuilderSpec
 ---@field BuilderName BuilderNames
 ---@field BuilderType BuilderType
----@field BuilderData table
+---@field BuilderData EngineDefinedField <table>
 ---@field PlatoonTemplate string
 ---@field Priority number
----@field InstanceCount number
----@field BuilderConditions BuilderCondition[]
+---@field InstanceCount EngineDefinedField <number>
+---@field BuilderConditions EngineDefinedField <BuilderCondition[]>
 
 -- Global list of all builders found in the game
 ---@type table<string, BuilderSpec>

--- a/lua/system/class.lua
+++ b/lua/system/class.lua
@@ -1,4 +1,8 @@
 ---@declare-global
+
+-- nilable alias used for fields that are defined in the engine during runtime (purely to prevent undefined field errors in the lua language server)
+---@alias EngineDefinedField<T> T | nil
+
 --- Class structure
 
 -- Simple class
@@ -167,7 +171,7 @@ end
 
 --- Prepares the construction of a class, referring to the paragraphs of text at the top of this file.
 ---@generic T: fa-class
----@generic T_Base: fa-class
+---@generic T_Base
 ---@param ... T_Base
 ---@return fun(specs: T): T|T_Base
 function Class(...)
@@ -198,7 +202,7 @@ function Class(...)
 end
 
 ---@generic T: fa-class
----@generic T_Base: fa-class
+---@generic T_Base
 ---@param ... T_Base
 ---@return fun(specs: T): T|T_Base
 function ClassUI(...)
@@ -217,7 +221,7 @@ function ClassUI(...)
 end
 
 ---@generic T: fa-class
----@generic T_Base: fa-class
+---@generic T_Base
 ---@param ... T_Base
 ---@return fun(specs: T): T|T_Base
 function ClassShield(...)
@@ -236,7 +240,7 @@ function ClassShield(...)
 end
 
 ---@generic T: fa-class
----@generic T_Base: fa-class
+---@generic T_Base
 ---@param ... T_Base
 ---@return fun(specs: T): T|T_Base
 function ClassProjectile(...)
@@ -255,7 +259,7 @@ function ClassProjectile(...)
 end
 
 ---@generic T: fa-class
----@generic T_Base: fa-class
+---@generic T_Base
 ---@param ... T_Base
 ---@return fun(specs: T): T|T_Base
 function ClassDummyProjectile(...)
@@ -274,7 +278,7 @@ function ClassDummyProjectile(...)
 end
 
 ---@generic T: fa-class
----@generic T_Base: fa-class
+---@generic T_Base
 ---@param ... T_Base
 ---@return fun(specs: T): T|T_Base
 function ClassUnit(...)
@@ -293,7 +297,7 @@ function ClassUnit(...)
 end
 
 ---@generic T: fa-class
----@generic T_Base: fa-class
+---@generic T_Base
 ---@param ... T_Base
 ---@return fun(specs: T): T|T_Base
 function ClassDummyUnit(...)
@@ -312,7 +316,7 @@ function ClassDummyUnit(...)
 end
 
 ---@generic T: fa-class
----@generic T_Base: fa-class
+---@generic T_Base
 ---@param ... T_Base
 ---@return fun(specs: T): T|T_Base
 function ClassWeapon(...)

--- a/lua/system/utils.lua
+++ b/lua/system/utils.lua
@@ -352,7 +352,7 @@ end
 ---   for k,v in sortedpairs(t) do
 ---       print(k,v)
 ---   end
---- @param comp is an optional comparison function, defaulting to less-than.
+--- @param comp any -- is an optional comparison function, defaulting to less-than.
 function sortedpairs(t, comp)
     local keys = table.keys(t, comp)
     local i=1
@@ -555,8 +555,8 @@ function table.print(tbl, tblPrefix, printer)
 end
 
 --- Return filtered table containing every mapping from table for which fn function returns true when passed the value.
---- @param t  - is a table to filter
---- @param fn - is decision function to use to filter the table, defaults checking if a value is true or exists in table
+--- @param t table - is a table to filter
+--- @param fn function - is decision function to use to filter the table, defaults checking if a value is true or exists in table
 function table.filter(t, fn)
     local r = {}
     if not fn then fn = function(v) return v end end
@@ -569,7 +569,7 @@ function table.filter(t, fn)
 end
 
 --- Returns total count of values that match fn function or if values exist in table
---- @param fn is optional filtering function that is applied to each value of the table
+--- @param fn function -- is optional filtering function that is applied to each value of the table
 function table.count(t, fn)
     if not t then return 0 end -- prevents looping over nil table
     if not fn then fn = function(v) return v end end
@@ -632,7 +632,7 @@ end
 
 --- "explode" a string into a series of tokens, using a separator character `sep`
 ---@param str string
----@param sep string
+---@param sep? string
 ---@return string[]
 function StringSplit(str, sep)
     local sep, fields = sep or ":", {}

--- a/lua/ui/game/chat/ChatCommandHintInterface.lua
+++ b/lua/ui/game/chat/ChatCommandHintInterface.lua
@@ -50,12 +50,12 @@ end
 
 --- One pooled hint row; ordinal 0 means hidden, otherwise it's the row's position from the bottom.
 ---@class UIChatHintRow
----@field Text    Text
----@field BG      Bitmap
+---@field Text    EngineDefinedField <Text>
+---@field BG      EngineDefinedField <Bitmap>
 ---@field Ordinal LazyVar<number>            # 0 = hidden, 1 = bottom row, growing upward
 ---@field Target  UIChatCommand | nil
----@field Hovered boolean
----@field Paint   fun()                       # re-applies BG solid-colour from Hovered + owner.Selected
+---@field Hovered EngineDefinedField <boolean>
+---@field Paint   EngineDefinedField <fun()>                       # re-applies BG solid-colour from Hovered + owner.Selected
 
 --- Slash-command auto-suggest popup anchored above the edit box; reuses a row pool across refreshes.
 ---@class UIChatCommandHintInterface : Group

--- a/lua/ui/game/chat/ChatModel.lua
+++ b/lua/ui/game/chat/ChatModel.lua
@@ -34,7 +34,7 @@ RecipientNotify = 'notify'
 ---@field BodyColor?  string             # explicit ARGB hex for the body text; bypasses the palette lookup (used by system / synthetic lines that always render the same colour)
 ---@field ColorKey?   string             # palette key (e.g. `'all_color'`, `'priv_color'`, `'link_color'`) resolved against `ChatConfigModel.GetOptions()` at render time; ignored when `BodyColor` is set
 ---@field ArmyID      number             # sender's army index
----@field Faction     number             # faction icon index (1-based)
+---@field Faction     EngineDefinedField <number>             # faction icon index (1-based)
 ---@field Recipient   UIChatRecipient    # the target this message was directed to
 ---@field Camera?     table              # camera state (`SaveSettings` snapshot) when the sender attached their exact view
 ---@field Location?   UIChatEntryLocation # lightweight location hint from a sim-originated sender (AI brain, system message)

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -83,7 +83,7 @@ local MathAtan = math.atan
 
 ---@class MeshInfo
 ---@field Position Vector
----@field Blueprint string
+---@field Blueprint EngineDefinedField <string>
 ---@field TextureName string
 ---@field ShaderName string
 ---@field UniformScale number

--- a/lua/ui/game/hotkeys/context-based-templates-data.lua
+++ b/lua/ui/game/hotkeys/context-based-templates-data.lua
@@ -23,8 +23,8 @@
 ---@class ContextBasedTemplate
 ---@field Name string                           # Printed on screen when cycling the templates
 ---@field TemplateData UIBuildTemplate          # A regular build template, except that it is written in Pascal Case and usually the first unit is removed
----@field TemplateSortingOrder number           # Lower numbers end up first in the queue
----@field TemplateBlueprintId BlueprintId       
+---@field TemplateSortingOrder EngineDefinedField <number>           # Lower numbers end up first in the queue
+---@field TemplateBlueprintId EngineDefinedField <BlueprintId>       
 ---
 --- By mouse context
 ---@field TriggersOnUnit? EntityCategory        # When defined, includes this template when the player is hovering over a unit, a build order for a given unit or a unit in build preview that matches the categories

--- a/lua/ui/game/orders.lua
+++ b/lua/ui/game/orders.lua
@@ -1085,10 +1085,10 @@ end
 ---@alias ToggleCap EngineToggleCap
 
 ---@class OrderInfo
----@field helpText string
----@field bitmapId string
----@field preferredSlot integer
----@field behavior function
+---@field helpText EngineDefinedField <string>
+---@field bitmapId EngineDefinedField <string>
+---@field preferredSlot EngineDefinedField <integer>
+---@field behavior EngineDefinedField <function>
 ---@field initialStateFunc? fun(control: Control, unitList: table<Unit>): any
 ---@field onframe? fun(control: Control, delta: number)
 ---@field ButtonTextFunc? fun(button: Button): string

--- a/lua/ui/game/ping.lua
+++ b/lua/ui/game/ping.lua
@@ -5,13 +5,13 @@ local UIUtil = import("/lua/ui/uiutil.lua")
 ---@alias PingTypeLowercase 'alert' | 'move' | 'attack' | 'marker'
 
 ---@class SyncPingData
----@field Owner integer # Army index of who sent the ping
----@field Location Vector # position
----@field Type PingType
----@field Lifetime number
----@field Ring FileName
----@field ArrowColor 'yellow' | 'blue' | 'red'
----@field Sound string # 'UI_Main_IG_Click'
+---@field Owner EngineDefinedField <integer> # Army index of who sent the ping
+---@field Location EngineDefinedField <Vector> # position
+---@field Type EngineDefinedField <PingType>
+---@field Lifetime EngineDefinedField <number>
+---@field Ring EngineDefinedField <FileName>
+---@field ArrowColor EngineDefinedField <'yellow' | 'blue' | 'red'>
+---@field Sound EngineDefinedField <string> # 'UI_Main_IG_Click'
 ---@field Marker? true
 ---@field Name? string # Text under the marker ping
 ---@field Color? string # Color of marker ping, matching army color.

--- a/lua/ui/game/reclaim.lua
+++ b/lua/ui/game/reclaim.lua
@@ -22,7 +22,7 @@ local TableGetn = table.getn
 ---@field mass number
 ---@field position Vector
 ---@field count number
----@field max number
+---@field max EngineDefinedField <number>
 
 ---@type number
 local HeightRatio = 0.020

--- a/lua/ui/lobby/autolobby/AutolobbyController.lua
+++ b/lua/ui/lobby/autolobby/AutolobbyController.lua
@@ -77,14 +77,14 @@ local AutolobbyEngineStrings = {
 ---| "" # when Division is grandmaster or unlisted
 
 ---@class UIAutolobbyPlayer: UILobbyLaunchPlayerConfiguration
----@field StartSpot number
----@field DEV number    # Related to rating/divisions
----@field MEAN number   # Related to rating/divisions
----@field NG number     # Related to rating/divisions
----@field DIV Division    # Related to rating/divisions
----@field SUBDIV Subdivision # Related to rating/divisions
----@field PL number     # Related to rating/divisions
----@field PlayerClan string
+---@field StartSpot EngineDefinedField <number>
+---@field DEV EngineDefinedField <number>    # Related to rating/divisions
+---@field MEAN EngineDefinedField <number>   # Related to rating/divisions
+---@field NG EngineDefinedField <number>     # Related to rating/divisions
+---@field DIV EngineDefinedField <Division>    # Related to rating/divisions
+---@field SUBDIV EngineDefinedField <Subdivision> # Related to rating/divisions
+---@field PL EngineDefinedField <number>     # Related to rating/divisions
+---@field PlayerClan EngineDefinedField <string>
 
 ---@alias UIAutolobbyConnections boolean[][]
 ---@alias UIAutolobbyStatus UIPeerLaunchStatus[]

--- a/lua/ui/lobby/lobbyOptions.lua
+++ b/lua/ui/lobby/lobbyOptions.lua
@@ -17,40 +17,40 @@
 
 --- Additionally, extra options can be specified by the map in `mapname .. 'options.lua'`
 ---@class GameOptions
----@field AutoTeams 'none' | 'manual' | 'tvsb' | 'lvsr' | 'pvsi'
----@field TeamLock 'locked' | 'unlocked'
----@field TeamSpawn 'fixed' | 'random' | 'balanced' | 'balanced_flex' | 'random_reveal' | 'balanced_reveal' | 'balanced_reveal_mirrored' | 'balanced_flex_reveal'
+---@field AutoTeams EngineDefinedField <'none' | 'manual' | 'tvsb' | 'lvsr' | 'pvsi'>
+---@field TeamLock EngineDefinedField <'locked' | 'unlocked'>
+---@field TeamSpawn EngineDefinedField <'fixed' | 'random' | 'balanced' | 'balanced_flex' | 'random_reveal' | 'balanced_reveal' | 'balanced_reveal_mirrored' | 'balanced_flex_reveal'>
 ---@field TeamShareOverflow "enabled" | "disabled"
 ---
----@field AllowObservers boolean
+---@field AllowObservers EngineDefinedField <boolean>
 ---@field CheatsEnabled 'false' | 'true'
 ---@field CivilianAlliance 'enemy' | 'neutral' | 'removed'
----@field DisconnectionDelay02 '10' | '30' | '90'
+---@field DisconnectionDelay02 EngineDefinedField <'10' | '30' | '90'>
 ---@field FogOfWar 'none' | 'explored'
 ---@field GameSpeed 'normal' | 'fast' | 'adjustable'
----@field ManualUnitShare 'none' | 'no_builders' | 'all'
+---@field ManualUnitShare EngineDefinedField <'none' | 'no_builders' | 'all'>
 ---@field NoRushOption '1' | '2' | '3' | '4' | '5' | '10' | '15' | '20' | '25' | '30' | '35' | '40' | '45' | '50' | '55' | '60' | 'Off'
 ---@field PrebuiltUnits 'Off' | 'On'
----@field Ranked boolean
----@field RevealCivilians 'No' | 'Yes'
----@field RandomMap 'Off' | 'Official' | 'All'
----@field Score 'no' | 'yes'
+---@field Ranked EngineDefinedField <boolean>
+---@field RevealCivilians EngineDefinedField <'No' | 'Yes'>
+---@field RandomMap EngineDefinedField <'Off' | 'Official' | 'All'>
+---@field Score EngineDefinedField <'no' | 'yes'>
 ---@field Share ShareOption
----@field DisconnectShare DisconnectShareOption
----@field DisconnectShareCommanders DisconnectShareCommandersOption
----@field ShareUnitCap 'none' | 'allies' | 'all'
+---@field DisconnectShare EngineDefinedField <DisconnectShareOption>
+---@field DisconnectShareCommanders EngineDefinedField <DisconnectShareCommandersOption>
+---@field ShareUnitCap EngineDefinedField <'none' | 'allies' | 'all'>
 ---@field Timeouts '0' | '3'| '-1' | -1
 ---@field UnitCap '125' | '250' | '375' | '500' | '625' | '750' | '875' | '1000' | '1250' | '1500'
----@field Unranked 'No' | 'Yes'
+---@field Unranked EngineDefinedField <'No' | 'Yes'>
 ---@field Victory VictoryCondition
----@field CommonArmy CommonArmyOption
+---@field CommonArmy EngineDefinedField <CommonArmyOption>
 ---
----@field BuildMult AIMultiplierOptionValue
----@field CheatMult AIMultiplierOptionValue
----@field LandExpansionsAllowed AIExpansionOptionValue
----@field NavalExpansionsAllowed AIExpansionOptionValue
----@field OmniCheat 'off' | 'on'
----@field TMLRandom '0' | '2.5' | '5' | '7.5' | '10' | '12.5' | '15' | '17.5' | '20'
+---@field BuildMult EngineDefinedField <AIMultiplierOptionValue>
+---@field CheatMult EngineDefinedField <AIMultiplierOptionValue>
+---@field LandExpansionsAllowed EngineDefinedField <AIExpansionOptionValue>
+---@field NavalExpansionsAllowed EngineDefinedField <AIExpansionOptionValue>
+---@field OmniCheat EngineDefinedField <'off' | 'on'>
+---@field TMLRandom EngineDefinedField <'0' | '2.5' | '5' | '7.5' | '10' | '12.5' | '15' | '17.5' | '20'>
 
 ---@class ScenarioOption
 ---@field default number

--- a/lua/ui/uiutil.lua
+++ b/lua/ui/uiutil.lua
@@ -1017,8 +1017,8 @@ end
 
 ---@class ModalityInfo
 ---@field escapeButton number `1-3` the button function to mimic when the escape button is pressed
----@field enterButton number `1-3` the button function to mimic when the enter button is pressed
----@field OnlyWorldCover boolean if only the world is covered (i.e. it's non-modal)
+---@field enterButton EngineDefinedField <number> `1-3` the button function to mimic when the enter button is pressed
+---@field OnlyWorldCover EngineDefinedField <boolean> if only the world is covered (i.e. it's non-modal)
 
 --- Creates and manages an info dialog. Setting a callback for a button will prevent it from closing
 --- the dialog unless `destroyOnCallback` is true (which is the default only when all three callbacks

--- a/tests/blueprint/unit.spec.lua
+++ b/tests/blueprint/unit.spec.lua
@@ -52,7 +52,7 @@ end
 function MeshBlueprint(bp)
     return bp
 end
-
+--#endregion
 -------------------------------------------------------------------------------
 
 
@@ -218,7 +218,7 @@ luft.describe(
                             end
                         )
                     end
-
+                    --#endregion
                     -----------------------------------------------------------
                     --#region Unique radia
 

--- a/units/XSB1104/XSB1104_unit.bp
+++ b/units/XSB1104/XSB1104_unit.bp
@@ -1,3 +1,8 @@
+--Many fields are handled by the engine, but not nullable, so UnitBlueprints.lua will flag errors without this.
+
+
+
+----@diagnostic disable: missing-fields
 UnitBlueprint{
     Description = "<LOC xsb1104_desc>Mass Fabricator",
     Adjacency = "T1MassFabricatorAdjacencyBuffs",


### PR DESCRIPTION
## **WIP PR**

## Description of the proposed changes

• This adds a generic alias annotation that can be applied to field annotations to stop language server errors for fields that will only be defined during runtime on the engine side.

• makes changes to class.lua to prevent errors from moho stuff in the FA class parameters

## Additional context

This is in preparation for the WIP [updated language server](https://github.com/Lightningbulb2/faf-lua-language-server-patch)

This PR's content was written entirely by hand besides the class.lua changes.


## Checklist
- [ ] Changes are annotated, including comments where useful
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved editor support for many game data/configuration fields, especially in blueprints, UI, AI, and lobby settings.
  * Added a reusable way to mark engine-filled fields, reducing false missing-field warnings and improving autocomplete.

* **Bug Fixes**
  * Fixed several Lua language-server annotation issues that could cause noisy type errors in project files.
  * Cleaned up a few formatting and documentation markers to keep tooling output stable.

* **Tests**
  * Updated test file section markers for clearer organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->