### PR TITLE
Fix init crash due to string mod version and prettify set mod list logging

### DIFF
--- a/changelog/snippets/category.7158.md
+++ b/changelog/snippets/category.7158.md
@@ -1,1 +1,0 @@
-- Your explanation here... [Don't forget to change the category in the filename] (#7158).

--- a/changelog/snippets/fix.7177.md
+++ b/changelog/snippets/fix.7177.md
@@ -1,0 +1,1 @@
+- (#7177) Fix non-number mod version numbers erroring in rule and session init (encountered with the AutoTML mod).

--- a/lua/MODS.LUA
+++ b/lua/MODS.LUA
@@ -463,9 +463,16 @@ local _mod_cache = nil
 ---@param selectedMods? uidSet set of mod UID's
 function SetSelectedMods(selectedMods)
     if selectedMods then
-        LOG("MOD LIST SET TO:")
+        LOG("Mod list set to:")
         for uid in selectedMods do
-            LOG("\t" .. tostring(_mod_cache[uid].name) .. "\t(" .. uid .. ")")
+            local info = _mod_cache[uid]
+            LOG(string.format('\t"[%3s] %-30s v%02s (%-37s by %s'
+                , info.ui_only and 'UI' or 'SIM'
+                , tostring(info.name) .. '"'
+                , tostring(info.version)
+                , tostring(info.uid) .. ')'
+                , tostring(info.author)
+            ))
         end
 
         SetPreference('active_mods', selectedMods)

--- a/lua/MODS.LUA
+++ b/lua/MODS.LUA
@@ -466,8 +466,8 @@ function SetSelectedMods(selectedMods)
         LOG("Mod list set to:")
         for uid in selectedMods do
             local info = _mod_cache[uid]
-            LOG(string.format('\t"[%3s] %-30s v%02s (%-37s by %s'
-                , info.ui_only and 'UI' or 'SIM'
+            LOG(string.format('\t%-5s "%-30s v%02s (%-37s by %s'
+                , info.ui_only and '[UI]' or '[SIM]'
                 , tostring(info.name) .. '"'
                 , tostring(info.version)
                 , tostring(info.uid) .. ')'

--- a/lua/RuleInit.lua
+++ b/lua/RuleInit.lua
@@ -21,7 +21,7 @@ doscript '/lua/system/debug.lua'
 
 LOG('Active game mods for blueprint loading:')
 for _, mod in __active_mods do
-    LOG(string.format('\t"%-30s v%02d (%-37s by %s', tostring(mod.name) .. '"', tostring(mod.version), tostring(mod.uid) .. ')', tostring(mod.author)))
+    LOG(string.format('\t"%-30s v%02s (%-37s by %s', tostring(mod.name) .. '"', tostring(mod.version), tostring(mod.uid) .. ')', tostring(mod.author)))
 end
 
 doscript '/lua/footprints.lua'

--- a/lua/RuleInit.lua
+++ b/lua/RuleInit.lua
@@ -21,7 +21,12 @@ doscript '/lua/system/debug.lua'
 
 LOG('Active game mods for blueprint loading:')
 for _, mod in __active_mods do
-    LOG(string.format('\t"%-30s v%02s (%-37s by %s', tostring(mod.name) .. '"', tostring(mod.version), tostring(mod.uid) .. ')', tostring(mod.author)))
+    LOG(string.format('\t"%-30s v%02s (%-37s by %s'
+        , tostring(mod.name) .. '"'
+        , tostring(mod.version)
+        , tostring(mod.uid) .. ')'
+        , tostring(mod.author)
+    ))
 end
 
 doscript '/lua/footprints.lua'

--- a/lua/SessionInit.lua
+++ b/lua/SessionInit.lua
@@ -15,7 +15,7 @@ end
 
 LOG('Active mods in session:')
 for _, mod in __active_mods do
-    LOG(string.format('\t"%-30s v%02d (%-37s by %s', tostring(mod.name) .. '"', tostring(mod.version), tostring(mod.uid) .. ')', tostring(mod.author)))
+    LOG(string.format('\t"%-30s v%02s (%-37s by %s', tostring(mod.name) .. '"', tostring(mod.version), tostring(mod.uid) .. ')', tostring(mod.author)))
 end
 
 doscript '/lua/UserSync.lua'

--- a/lua/SessionInit.lua
+++ b/lua/SessionInit.lua
@@ -15,7 +15,12 @@ end
 
 LOG('Active mods in session:')
 for _, mod in __active_mods do
-    LOG(string.format('\t"%-30s v%02s (%-37s by %s', tostring(mod.name) .. '"', tostring(mod.version), tostring(mod.uid) .. ')', tostring(mod.author)))
+    LOG(string.format('\t"%-30s v%02s (%-37s by %s'
+        , tostring(mod.name) .. '"'
+        , tostring(mod.version)
+        , tostring(mod.uid) .. ')'
+        , tostring(mod.author)
+    ))
 end
 
 doscript '/lua/UserSync.lua'

--- a/lua/ui/lobby/ModsManager.lua
+++ b/lua/ui/lobby/ModsManager.lua
@@ -294,8 +294,6 @@ function CreateDialog(parent, isHost, availableMods, saveBehaviour)
                 end
             )
             mods.sim.active = SetUtils.Subtract(mods.activated, mods.ui.active)
-            table.print(mods.sim.active, 'mods.sim.active')
-            table.print(mods.ui.active, 'mods.ui.active')
 
             callback(mods.sim.active, mods.ui.active)
         else


### PR DESCRIPTION
## Issue
The mod "AutoTML" has `version="1.1.1"`, which causes rule and session init files to error because the string format function was using `d` (digit) to format the version, and "1.1.1" cannot be converted to that.

## Description of the proposed changes
Change the format identifier from `d` to `s` (string).

I noticed that the mods list printing was very long and hard to understand due to debug prints. I copied the style used in the init files over and removed the debug-style `table.print` statements.

## Testing done on the proposed changes
run `LOG(string.format("%s", "1.1.1"))` in console and it does not error and produces the correct output.

The mod list output is lined up correctly:
```
info: Mod list set to:
info:         [UI]  "Common Mod Tools"              v01 (zcbf6277-24e3-437a-b968-Common-v1)    by Crotalus
info:         [UI]  "ReUI"                          v06 (reui-1.3.1)                           by 4z0t
info:         [SIM] "2% Particles"                  v01 (ab88d092-fae3-46e2-8224-53a47db7aa59) by CatmanFS
info:         [UI]  "Penguin's Icon Mod"            v02 (3ccc4eca-0cb1-11ec-ac65-a37599393411-02) by EmperorPenguin
info:         [UI]  "Selection Cost UI"             v09 (2018eaac-e8ed-11e4-b02c-1681e6b44c9)  by Eternal-
```

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
