### PR TITLE
Re-add DummyUnit import to defaultunits.lua

### DIFF
--- a/changelog/snippets/fix.7180.md
+++ b/changelog/snippets/fix.7180.md
@@ -1,0 +1,1 @@
+- Re-add missing `DummyUnit` import to `defaultunits.lua` needed for mod compatibility (specifically BrewLAN Research & Daiquiris) (#7180)

--- a/lua/defaultunits.lua
+++ b/lua/defaultunits.lua
@@ -55,6 +55,8 @@ ExternalFactoryUnit = import("/lua/sim/units/externalfactoryunit.lua").ExternalF
 -------------------------------------------------------------------------------
 --#region Backwards compatibility
 
+DummyUnit = import("/lua/sim/unit.lua").DummyUnit
+
 local Entity = import("/lua/sim/entity.lua").Entity
 local Unit = import("/lua/sim/unit.lua").Unit
 local explosion = import("/lua/defaultexplosions.lua")


### PR DESCRIPTION
## Issue
Reported on [Discord](https://discord.com/channels/197033481883222026/1527337132585386165).
BrewLAN_Units Research & Daiquiris mod expected class DummyUnit in defaultunits.lua
```
info: Hooked /lua/defaultunits.lua with /mods/brewlan/hook/lua/defaultunits.lua
info: Hooked /lua/defaultunits.lua with /mods/brewlan_units/brewresearch/hook/lua/defaultunits.lua
...
warning: ...data\faforever\gamedata\lua.nx2\lua\defaultunits.lua(147): access to nonexistent global variable "DummyUnit"
```

The reference was removed in #3697 due to the PRs #3441 and #3636 moving the class to Unit.lua.

## Description of the proposed changes
Add back the reference to the defaultunits.lua file.

## Testing done on the proposed changes
Loaded the mod with the changes and the game started successfully with no errors.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the missing `DummyUnit` compatibility import, resolving mod compatibility issues for BrewLAN Research & Daiquiris.
* **Documentation**
  * Added a changelog entry documenting the compatibility fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->