### PR TITLE
Balance T1 Aeon stationary AA 

### DIFF
--- a/changelog/snippets/balance.7182.md
+++ b/changelog/snippets/balance.7182.md
@@ -1,6 +1,6 @@
 {% unit UAB2104 %}
 Seeker: T1 Anti-Air Turret
 {% endunit %}
-The Aeon T1 AA turret was weaker than the equivalent units of the other factions, which made it struggle more against T1 bombers and T2 GS than expected. For comparison, the UEF and Seraphim turrets have 65.71 and 66.67 DPS, respectively. (#7182)
+The Aeon T1 AA turret was weaker than the equivalent units of the other factions, which made it struggle more against T1 bombers and T2 gunships than expected. For comparison, the UEF and Seraphim turrets have 65.71 and 66.67 DPS, respectively. (#7182)
 - Sonic Pulse Battery:
   - Damage (DPS): 14 (60) -> 15 (64.29)

--- a/changelog/snippets/balance.7182.md
+++ b/changelog/snippets/balance.7182.md
@@ -1,6 +1,6 @@
 {% unit UAB2104 %}
 Seeker: T1 Anti-Air Turret
 {% endunit %}
-The Aeon T1 AA turret was weaker than the equivalent units of the other factions, which made it struggle more against T1 bombers and T2 GS than expected. For comparison, the UEF and Seraphim turrets have 66.67 and 65.71 DPS, respectively. (#7182)
+The Aeon T1 AA turret was weaker than the equivalent units of the other factions, which made it struggle more against T1 bombers and T2 GS than expected. For comparison, the UEF and Seraphim turrets have 65.71 and 66.67 DPS, respectively. (#7182)
 - Sonic Pulse Battery:
   - Damage (DPS): 14 (60) -> 15 (64.29)

--- a/changelog/snippets/balance.7182.md
+++ b/changelog/snippets/balance.7182.md
@@ -1,6 +1,6 @@
 {% unit UAB2104 %}
 Seeker: T1 Anti-Air Turret
 {% endunit %}
-The Aeon T1 AA turret was weaker than the equivalent units of the other factions, which made it struggle more against T1 bombers and T2 GS than expected. For comparison, the UEF and Seraphim turrets have 66.67 and 65.71 DPS, respectively. (#1234)
+The Aeon T1 AA turret was weaker than the equivalent units of the other factions, which made it struggle more against T1 bombers and T2 GS than expected. For comparison, the UEF and Seraphim turrets have 66.67 and 65.71 DPS, respectively. (#7182)
 - Sonic Pulse Battery:
   - Damage (DPS): 14 (60) -> 15 (64.29)

--- a/changelog/snippets/balance.7182.md
+++ b/changelog/snippets/balance.7182.md
@@ -1,0 +1,6 @@
+{% unit UAB2104 %}
+Seeker: T1 Anti-Air Turret
+{% endunit %}
+The Aeon T1 AA turret was weaker than the equivalent units of the other factions, which made it struggle more against T1 bombers and T2 GS than expected. For comparison, the UEF and Seraphim turrets have 66.67 and 65.71 DPS, respectively. (#1234)
+- Sonic Pulse Battery:
+  - Damage (DPS): 14 (60) -> 15 (64.29)

--- a/units/UAB2104/UAB2104_unit.bp
+++ b/units/UAB2104/UAB2104_unit.bp
@@ -134,7 +134,7 @@ UnitBlueprint{
             BallisticArc = "RULEUBA_None",
             CannotAttackGround = true,
             CollideFriendly = false,
-            Damage = 14,
+            Damage = 15,
             DamageType = "Normal",
             DisplayName = "Sonic Pulse Battery",
             FireTargetLayerCapsTable = {


### PR DESCRIPTION
## Description of the proposed changes
The Aeon T1 AA turret is weaker than the equivalent units of the other factions, which makes it struggle more against T1 bombers and T2 GS than expected.

```
Seeker: T1 Anti-Air Turret (XSS0201):
  Sonic Pulse Battery: Damage 14 -> 15 [DPS: 60 -> 64.29]
```

Current balance:
|Aeon|Cybran|Seraphim|UEF|
|------|--------|----------|----|
|60|70|65.71|66.67|

## Checklist
- [ ] ~Changes are annotated, including comments where useful~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Balance Changes**
  * Increased the Sonic Pulse Battery’s damage from 14 to 15 per hit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->