### PR TITLE
Improve PR prep workflow to create appropriate category snippets

### DIFF
--- a/.github/workflows/pr-preparation.yaml
+++ b/.github/workflows/pr-preparation.yaml
@@ -44,13 +44,13 @@ jobs:
           IS_GRAPHICS: "${{ contains(github.event.pull_request.labels.*.name, 'area: graphics') }}"
           IS_AI: "${{ contains(github.event.pull_request.labels.*.name, 'area: AI') }}"
           # Performance snippet category - no associated label
-          IS_BALANCE: |
+          IS_BALANCE: >
             "${{ contains(github.event.pull_request.labels.*.name, 'area: balance') 
               || contains(github.event.pull_request.labels.*.name, 'area: balance idea') 
             }}"
           # Features snippet category - no associated label
           IS_FIX: "${{ contains(github.event.pull_request.labels.*.name, 'type: bug') }}"
-          IS_OTHER: | 
+          IS_OTHER: > 
             "${{ contains(github.event.pull_request.labels.*.name, 'area: documentation') 
                 || contains(github.event.pull_request.labels.*.name, 'area: tooling') 
               }}"

--- a/.github/workflows/pr-preparation.yaml
+++ b/.github/workflows/pr-preparation.yaml
@@ -40,21 +40,42 @@ jobs:
         working-directory: changelog/snippets
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          IS_BALANCE: "${{ contains(github.event.pull_request.labels.*.name, 'area: balance') || contains(github.event.pull_request.labels.*.name, 'area: balance idea') }}"
+          # Priority order as documented in /docs/development-changelog.md
+          IS_GRAPHICS: "${{ contains(github.event.pull_request.labels.*.name, 'area: graphics') }}"
+          IS_AI: "${{ contains(github.event.pull_request.labels.*.name, 'area: AI') }}"
+          # Performance snippet category - no associated label
+          IS_BALANCE: |
+            "${{ contains(github.event.pull_request.labels.*.name, 'area: balance') 
+              || contains(github.event.pull_request.labels.*.name, 'area: balance idea') 
+            }}"
+          # Features snippet category - no associated label
+          IS_FIX: "${{ contains(github.event.pull_request.labels.*.name, 'type: bug') }}"
+          IS_OTHER: | 
+            "${{ contains(github.event.pull_request.labels.*.name, 'area: documentation') 
+                || contains(github.event.pull_request.labels.*.name, 'area: tooling') 
+              }}"
         run: |
           # Configure git
           git config user.email "github@faforever.com"
           git config user.name "FAForever Machine User"
 
-          if [ "$IS_BALANCE" = "true" ]; then
-            FILE="balance.${PR_NUMBER}.md"
-            cp sections/template-snippet-balance.md "$FILE"
-            sed -i "s/PR_NUMBER/${PR_NUMBER}/g" "$FILE"
-          else
-            FILE="category.${PR_NUMBER}.md"
-            cp sections/template-snippet.md "$FILE"
-            sed -i "s/XYZW/${PR_NUMBER}/g" "$FILE"
+          category="category"
+          template="sections/template-snippet.md"
+          if [ "$IS_GRAPHICS" = "true" ]; then
+            category="graphics"
+          elif [ "$IS_AI" = "true" ]; then
+            category="ai"
+          elif [ "$IS_BALANCE" = "true" ]; then
+            category="balance"
+            template="sections/template-snippet-balance.md"
+          elif [ "$IS_FIX" = "true" ]; then
+            category="fix"
+          elif [ "$IS_OTHER" = "true" ]; then
+            category="other"
           fi
+          file="${category}.${PR_NUMBER}.md"
+          cp "$template" "$file"
+          sed -i "s/PR_NUMBER/${PR_NUMBER}/g" "$file"
 
           git add .
           git commit -m "Add snippet template"

--- a/.github/workflows/pr-preparation.yaml
+++ b/.github/workflows/pr-preparation.yaml
@@ -44,10 +44,7 @@ jobs:
           IS_GRAPHICS: "${{ contains(github.event.pull_request.labels.*.name, 'area: graphics') }}"
           IS_AI: "${{ contains(github.event.pull_request.labels.*.name, 'area: AI') }}"
           # Performance snippet category - no associated label
-          IS_BALANCE: >
-            "${{ contains(github.event.pull_request.labels.*.name, 'area: balance') 
-              || contains(github.event.pull_request.labels.*.name, 'area: balance idea') 
-            }}"
+          IS_BALANCE: "${{ contains(github.event.pull_request.labels.*.name, 'area: balance idea') }}"
           # Features snippet category - no associated label
           IS_OTHER: > 
             "${{ contains(github.event.pull_request.labels.*.name, 'area: documentation') 

--- a/.github/workflows/pr-preparation.yaml
+++ b/.github/workflows/pr-preparation.yaml
@@ -40,7 +40,7 @@ jobs:
         working-directory: changelog/snippets
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          IS_BALANCE: ${{ contains(github.event.pull_request.labels.*.name, 'area: balance') || contains(github.event.pull_request.labels.*.name, 'area: balance idea') }}
+          IS_BALANCE: "${{ contains(github.event.pull_request.labels.*.name, 'area: balance') || contains(github.event.pull_request.labels.*.name, 'area: balance idea') }}"
         run: |
           # Configure git
           git config user.email "github@faforever.com"

--- a/.github/workflows/pr-preparation.yaml
+++ b/.github/workflows/pr-preparation.yaml
@@ -40,14 +40,13 @@ jobs:
         working-directory: changelog/snippets
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          IS_BALANCE: ${{ contains(github.event.pull_request.labels.*.name, 'area: balance') || contains(github.event.pull_request.labels.*.name, 'area: balance idea') }}
         run: |
           # Configure git
           git config user.email "github@faforever.com"
           git config user.name "FAForever Machine User"
 
-          LABELS="$(echo '${{ toJson(github.event.pull_request.labels) }}' | jq -r '.[].name')"
-
-          if echo "$LABELS" | grep -Eq '^(area: balance|area: balance idea)$'; then
+          if [ "$IS_BALANCE" = "true" ]; then
             FILE="balance.${PR_NUMBER}.md"
             cp sections/template-snippet-balance.md "$FILE"
             sed -i "s/PR_NUMBER/${PR_NUMBER}/g" "$FILE"

--- a/.github/workflows/pr-preparation.yaml
+++ b/.github/workflows/pr-preparation.yaml
@@ -49,11 +49,11 @@ jobs:
               || contains(github.event.pull_request.labels.*.name, 'area: balance idea') 
             }}"
           # Features snippet category - no associated label
-          IS_FIX: "${{ contains(github.event.pull_request.labels.*.name, 'type: bug') }}"
           IS_OTHER: > 
             "${{ contains(github.event.pull_request.labels.*.name, 'area: documentation') 
                 || contains(github.event.pull_request.labels.*.name, 'area: tooling') 
               }}"
+          IS_FIX: "${{ contains(github.event.pull_request.labels.*.name, 'type: bug') }}"
         run: |
           # Configure git
           git config user.email "github@faforever.com"
@@ -68,10 +68,10 @@ jobs:
           elif [ "$IS_BALANCE" = "true" ]; then
             category="balance"
             template="sections/template-snippet-balance.md"
-          elif [ "$IS_FIX" = "true" ]; then
-            category="fix"
           elif [ "$IS_OTHER" = "true" ]; then
             category="other"
+          elif [ "$IS_FIX" = "true" ]; then
+            category="fix"
           fi
           file="${category}.${PR_NUMBER}.md"
           cp "$template" "$file"

--- a/.github/workflows/pr-preparation.yaml
+++ b/.github/workflows/pr-preparation.yaml
@@ -38,15 +38,25 @@ jobs:
 
       - name: Add snippet
         working-directory: changelog/snippets
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           # Configure git
           git config user.email "github@faforever.com"
           git config user.name "FAForever Machine User"
-          
-          FILE=category.${{ github.event.pull_request.number }}.md
-          cp sections/template-snippet.md $FILE
-          sed -i "s/XYZW/${{ github.event.pull_request.number }}/g" $FILE
-          
+
+          LABELS="$(echo '${{ toJson(github.event.pull_request.labels) }}' | jq -r '.[].name')"
+
+          if echo "$LABELS" | grep -Eq '^(area: balance|area: balance idea)$'; then
+            FILE="balance.${PR_NUMBER}.md"
+            cp sections/template-snippet-balance.md "$FILE"
+            sed -i "s/PR_NUMBER/${PR_NUMBER}/g" "$FILE"
+          else
+            FILE="category.${PR_NUMBER}.md"
+            cp sections/template-snippet.md "$FILE"
+            sed -i "s/XYZW/${PR_NUMBER}/g" "$FILE"
+          fi
+
           git add .
           git commit -m "Add snippet template"
           git push

--- a/changelog/snippets/sections/template-snippet-balance.md
+++ b/changelog/snippets/sections/template-snippet-balance.md
@@ -1,0 +1,6 @@
+{% unit <BlueprintID> %}
+<Formatted Unit Name>
+{% endunit %}
+<Description> (#PR_NUMBER)
+- <Category>:
+  - <Parameter Name>: <value before> -> <value after>

--- a/changelog/snippets/sections/template-snippet.md
+++ b/changelog/snippets/sections/template-snippet.md
@@ -1,1 +1,1 @@
-- Your explanation here... [Don't forget to change the category in the filename] (#XYZW).
+- Your explanation here... [Don't forget to change the category in the filename] (#PR_NUMBER).

--- a/docs/development-changelog.md
+++ b/docs/development-changelog.md
@@ -26,13 +26,13 @@ The format of a snippet depends on whether it is a [balance snippet](../developm
 
 ### Choosing a category
 
-1. `graphics` is everything graphics related.
-2. `ai` is everything AI related, for example new features that AI modders can use, or new capabilities of the AI.
+1. `graphics` is everything graphics-related.
+2. `ai` is everything AI-related, for example new features that AI modders can use, or new capabilities of the AI.
 3. `performance` is for changes that were made to increase the performance of the game.
 4. `balance` are changes that are made to improve the balance of the game.
 5. `features` is for new features that are available for the players in the game.
 6. `fix` is for fixes of bugs in the game. Bugs regarding intellisense or other areas outside of the game should go into `other`.
-7. `other` Refactors, changes for developers and modders, code annotations and the like fall into this category.
+7. `other` is for Refactors, changes for developers and modders, code annotations and the like fall into this category.
 
 If multiple categories are fitting, use the one that appears first in this list.
 

--- a/docs/development-changelog.md
+++ b/docs/development-changelog.md
@@ -26,13 +26,13 @@ The format of a snippet depends on whether it is a [balance snippet](../developm
 
 ### Choosing a category
 
-`graphics` is everything graphics related.
-`ai` is everything AI related, for example new features that AI modders can use, or new capabilities of the AI.
-`performance` is for changes that were made to increase the performance of the game.
-`balance` are changes that are made to improve the balance of the game.
-`features` is for new features that are available for the players in the game.
-`fix` is for fixes of bugs in the game. Bugs regarding intellisense or other areas outside of the game should go into `other`.
-`other` Refactors, changes for developers and modders, code annotations and the like fall into this category.
+1. `graphics` is everything graphics related.
+2. `ai` is everything AI related, for example new features that AI modders can use, or new capabilities of the AI.
+3. `performance` is for changes that were made to increase the performance of the game.
+4. `balance` are changes that are made to improve the balance of the game.
+5. `features` is for new features that are available for the players in the game.
+6. `fix` is for fixes of bugs in the game. Bugs regarding intellisense or other areas outside of the game should go into `other`.
+7. `other` Refactors, changes for developers and modders, code annotations and the like fall into this category.
 
 If multiple categories are fitting, use the one that appears first in this list.
 

--- a/docs/development-changelog.md
+++ b/docs/development-changelog.md
@@ -29,10 +29,10 @@ The format of a snippet depends on whether it is a [balance snippet](../developm
 1. `graphics` is everything graphics-related.
 2. `ai` is everything AI-related, for example new features that AI modders can use, or new capabilities of the AI.
 3. `performance` is for changes that were made to increase the performance of the game.
-4. `balance` are changes that are made to improve the balance of the game.
+4. `balance` is for changes that are made to improve the balance of the game.
 5. `features` is for new features that are available for the players in the game.
-6. `fix` is for fixes of bugs in the game. Bugs regarding intellisense or other areas outside of the game should go into `other`.
-7. `other` is for Refactors, changes for developers and modders, code annotations and the like fall into this category.
+6. `fix` is for fixes of bugs in the game. Bugs regarding IntelliSense or other areas outside the game should go into `other`.
+7. `other` is for refactors, changes for developers and modders, and code annotations.
 
 If multiple categories are fitting, use the one that appears first in this list.
 


### PR DESCRIPTION
## Description of the proposed changes
Create snippets with the correct template and filename based on the PR's labels upon creation.

## Testing done on the proposed changes
none

## Checklist
- [ ] Changes are annotated, including comments where useful
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Changelog preparation now selects the appropriate snippet category automatically based on pull request labels.
  * Added dedicated support for balance-related changelog entries, including structured unit details.

* **Documentation**
  * Updated changelog templates to use consistent pull request references.
  * Clarified category selection with a numbered list and improved formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->