### PR TITLE
Reduce strat bomber lift factor 10 -> 7

### DIFF
--- a/changelog/snippets/balance.7196.md
+++ b/changelog/snippets/balance.7196.md
@@ -1,0 +1,6 @@
+{% unit <UEA0304> %}
+T3 Strategic Bombers
+{% endunit %}
+Revert the lift factor change from the last strat bomber buff (#6535) to try to increase the reliability of bomb drops when the bomber flies over hills. A reduced lift factor makes aircraft move slower up and down. (#7196)
+- T3 Strategic Bombers:
+  - Lift Factor: 10 -> 7

--- a/changelog/snippets/category.7196.md
+++ b/changelog/snippets/category.7196.md
@@ -1,0 +1,1 @@
+- Your explanation here... [Don't forget to change the category in the filename] (#7196).

--- a/changelog/snippets/category.7196.md
+++ b/changelog/snippets/category.7196.md
@@ -1,1 +1,0 @@
-- Your explanation here... [Don't forget to change the category in the filename] (#7196).

--- a/units/UAA0304/UAA0304_unit.bp
+++ b/units/UAA0304/UAA0304_unit.bp
@@ -20,7 +20,7 @@ UnitBlueprint{
         KRollDamping = 2,
         KTurn = 0.8,
         KTurnDamping = 1,
-        LiftFactor = 10,
+        LiftFactor = 7,
         MaxAirspeed = 17,
         MinAirspeed = 15,
         PredictAheadForBombDrop = 3,

--- a/units/UEA0304/UEA0304_unit.bp
+++ b/units/UEA0304/UEA0304_unit.bp
@@ -20,7 +20,7 @@ UnitBlueprint{
         KRollDamping = 2,
         KTurn = 0.8,
         KTurnDamping = 1,
-        LiftFactor = 10,
+        LiftFactor = 7,
         MaxAirspeed = 17,
         MinAirspeed = 15,
         PredictAheadForBombDrop = 3,

--- a/units/URA0304/URA0304_unit.bp
+++ b/units/URA0304/URA0304_unit.bp
@@ -20,7 +20,7 @@ UnitBlueprint{
         KRollDamping = 2,
         KTurn = 0.8,
         KTurnDamping = 1,
-        LiftFactor = 10,
+        LiftFactor = 7,
         MaxAirspeed = 17,
         MinAirspeed = 15,
         PredictAheadForBombDrop = 3,

--- a/units/XSA0304/XSA0304_unit.bp
+++ b/units/XSA0304/XSA0304_unit.bp
@@ -20,7 +20,7 @@ UnitBlueprint{
         KRollDamping = 2,
         KTurn = 0.8,
         KTurnDamping = 1,
-        LiftFactor = 10,
+        LiftFactor = 7,
         MaxAirspeed = 17,
         MinAirspeed = 15,
         PredictAheadForBombDrop = 3,


### PR DESCRIPTION
## Issue
I've seen a few replays where strat bombers fail to drop due to terrain, and from the complaints I've read it seems to happen more often.
The specific replay that these changes are based off of is #27482296. In the late game after losing his arty and while making telemazer, waffelznoob sends 5 stealth strats right across this direction:
<img width="715" height="1024" alt="image" src="https://github.com/user-attachments/assets/2556b3d5-9582-445b-aa43-b7a2b12878d3" />

The high height caused them to not drop their bomb.
<img width="1145" height="734" alt="image" src="https://github.com/user-attachments/assets/10b1f0e6-039c-4bb1-8da6-72c925f3e0a8" />

## Description of the proposed changes
I replicated the scenario in a sandbox and tried to reduce how often strats would fail to drop. I found that reverting the lift factor change from #6535 increased the drop chance.

Lift factor 10 -> 7

## Testing done on the proposed changes
Use the following command by putting your cursor over the mex south of the triangular plateau on the map.
```
   CreateUnitAtMouse('uab1302', 1,   0,    0,  0.00000)
   CreateUnitAtMouse('ual0309', 1,  -31.06,   -6.00,  0.11737)
```
The engineer will be close to where you should groundfire strats to replicate the scenario from the replay.
I only tested with Cybran strats and I don't think there should be a noticeable difference for other strats.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved strategic bomber flight behavior over hills.
  * Increased the reliability of bomb drops during hill crossings.

* **Revert**
  * Reverted the previous lift-factor adjustment for T3 strategic bombers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->