### PR TITLE
Fix Salem's wobble due to alt and main footprint size difference

### DIFF
--- a/changelog/snippets/fix.7200.md
+++ b/changelog/snippets/fix.7200.md
@@ -1,0 +1,1 @@
+- Fix salem wiggling and locking up when issued lots of move orders. This is done by changing the 5x5 floating/hover footprint spec to 4x4, which only affects Salem in FAF but may affect large floating/hover units in mods by making them occupy slightly less space. (#7200)

--- a/lua/footprints.lua
+++ b/lua/footprints.lua
@@ -35,7 +35,7 @@ SpecFootprints {
     { Name = 'WaterLand1x1',   SizeX=1,  SizeZ=1,  Caps=LAND|WATER, MaxWaterDepth=1, MinWaterDepth=0.1, MaxSlope=0.75, Flags=0 },
     { Name = 'WaterLand2x2',   SizeX=2,  SizeZ=2,  Caps=LAND|WATER, MaxWaterDepth=1, MinWaterDepth=0.1, MaxSlope=0.75, Flags=0 },
     { Name = 'WaterLand3x3',   SizeX=3,  SizeZ=3,  Caps=LAND|WATER, MaxWaterDepth=5, MinWaterDepth=0, MaxSlope=0.75, Flags=0 },
-    { Name = 'WaterLand5x5',   SizeX=5,  SizeZ=5,  Caps=LAND|WATER, MaxWaterDepth=5, MinWaterDepth=0, MaxSlope=0.75, Flags=0 },
+    { Name = 'WaterLand4x4',   SizeX=4,  SizeZ=4,  Caps=LAND|WATER, MaxWaterDepth=5, MinWaterDepth=0, MaxSlope=0.75, Flags=0 },
 
     { Name = 'SurfacingSub2x2',   SizeX=2,  SizeZ=2,  Caps=SUB|WATER, MinWaterDepth=1.5, Flags=0 },
     { Name = 'SurfacingSub3x3',   SizeX=3,  SizeZ=3,  Caps=SUB|WATER, MinWaterDepth=1.5, Flags=0 },


### PR DESCRIPTION
```
I found that the main and alt footprints not matching in size is the issue. This makes sense because footprints are used for pathfinding structures according to `footprints.lua`, and if you switch pathfinding structs then I guess it just breaks.
To test this change we need to see in `footprints.lua` what footprints are available. We're interested in "WaterLand" and "Water" footprint types. Currently salem is trying to define its footprints in the bp as 2x8 for both main and alt, which when conforming to footprints.lua makes a main 5x5 (waterland) and alt 4x4 (water) (idk why the engine chooses these). If we change the bp definitions to 3x3 for both then the issue stops happening. If footprints.lua adds a 5x5 water footprint it also stops.

(c) Nomander
```
We decided to changed 5x5 water|land to 4x4 since there is no unit that uses that footprint (there are only engineers that use water|land from what we see)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Salem movement lockups when handling many move orders by reducing its floating footprint from 5×5 to 4×4.
  * Large floating or hover-based mod units may be affected by this footprint adjustment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->