### PR TITLE
Fix images in changelog not loading

### DIFF
--- a/changelog/snippets/balance.7121.md
+++ b/changelog/snippets/balance.7121.md
@@ -1,6 +1,6 @@
-- (#7121) Reduce stun duration of Loyalist's Disintegrator Pulse Laser since it was extremely powerful against T2 units, Ilshavohs in particular.
-
-  **Loyalist: T3 Siege Assault Bot**
-    - Disintegrator Pulse Laser:
-      - Stun Duration against T1/T2 mobile units: 1.5s per shot (2.3s per volley) (70% stun uptime) -> 0.4s per shot (1.2s per volley) (36% stun uptime)
-
+{% unit URL0303 %}
+Loyalist: T3 Siege Assault Bot
+{% endunit %}
+Reduce stun duration of Loyalist's Disintegrator Pulse Laser since it was extremely powerful against T2 units, Ilshavohs in particular (#7121).
+- Disintegrator Pulse Laser:
+  - Stun Duration against T1/T2 mobile units: 1.5s per shot (2.3s per volley) (70% stun uptime) -> 0.4s per shot (1.2s per volley) (36% stun uptime)

--- a/changelog/snippets/balance.7123.md
+++ b/changelog/snippets/balance.7123.md
@@ -1,23 +1,22 @@
-- (#7123) Reduce Novax's ability to kill many shields, T2 fabs, and engineers in a single volley, and rebalance its costs to make it more vulnerable to artillery fire, especially when built in large numbers.
+{% unit XEB2402 %}
+Novax Center: Experimental Satellite System
+{% endunit %}
+Reduce Novax's ability to kill many shields, T2 fabs, and engineers in a single volley, and rebalance its costs to make it more vulnerable to artillery fire, especially when built in large numbers (#7123).
+- Defense Satellite's Orbital Death Laser:
+  - Beam Lifetime: 8.1s -> 5.4s
+  - Damage: 60 (4860 per volley) -> 90 (4860 per volley)
+  - Damage Radius: 1 -> 0.5
+  - Aim Speed: 360 deg/s -> 8 deg/s
+  - Charge cost: 0 E -> 72000 E (3750 E/s average)
+  - Charge drain rate: 0 E -> 5000 E/s
+- Base Station:
+  - Mass cost: 36000 -> 32000
+  - Energy cost: 512000 -> 800000
+  - Build time: 44800 -> 43600
 
-  **Novax Center: Experimental Satellite System (XEB2402, XEA0002)**
-    - Defense Satellite's Orbital Death Laser:
-      - Beam Lifetime: 8.1s -> 5.4s
-      - Damage: 60 (4860 per volley) -> 90 (4860 per volley)
-      - Damage Radius: 1 -> 0.5
-      - Aim Speed: 360 deg/s -> 8 deg/s
-      - Charge cost: 0 E -> 72000 E (3750 E/s average)
-      - Charge drain rate: 0 E -> 5000 E/s
-    - Base Station:
-      - Mass cost: 36000 -> 32000
-      - Energy cost: 512000 -> 800000
-      - Build time: 44800 -> 43600
-    
-    The build cost is reduced by the cost of power generators (with storage adjacency) required to power the satellite's firing cost. The energy cost is increased to guide players towards building the power required for firing before building the Novax.
+The build cost is reduced by the cost of power generators (with storage adjacency) required to power the satellite's firing cost. The energy cost is increased to guide players towards building the power required for firing before building the Novax.
 
-- (#7123) Remove Omni from the Novax as it unnecessarily counters cloak which is already more than sufficiently countered by T3 Omni radars. Since Omni can detect underwater units, sonar is added to partially keep that interaction.
-
-  **Novax Center: Experimental Satellite System (XEB2402, XEA0002)**
-  - Defense Satellite:
-    - Omni radius: 60 -> 0
-    - Sonar radius: 0 -> 60
+Remove Omni from the Novax as it unnecessarily counters cloak which is already more than sufficiently countered by T3 Omni radars. Since Omni can detect underwater units, sonar is added to partially keep that interaction.
+- Defense Satellite:
+  - Omni radius: 60 -> 0
+  - Sonar radius: 0 -> 60

--- a/changelog/snippets/category.7202.md
+++ b/changelog/snippets/category.7202.md
@@ -1,0 +1,1 @@
+- Your explanation here... [Don't forget to change the category in the filename] (#7202).

--- a/changelog/snippets/category.7202.md
+++ b/changelog/snippets/category.7202.md
@@ -1,1 +1,0 @@
-- Your explanation here... [Don't forget to change the category in the filename] (#7202).

--- a/changelog/snippets/features.7066.md
+++ b/changelog/snippets/features.7066.md
@@ -1,1 +1,1 @@
-- (#7066) Add a quick load hotkey that loads the game from the special quick save file.
+- Add a quick load hotkey that loads the game from the special quick save file (#7066).

--- a/changelog/snippets/features.7098.md
+++ b/changelog/snippets/features.7098.md
@@ -1,18 +1,18 @@
-- (#7098, #7148, #7157) Rework the chat window
+- Rework the chat window (#7098, #7148, #7157).
 
-The chat window is re-implemented from scratch. It is rebuilt using the MVC-principle, creating a clear separation between state, viewing the state and interacting with the state. This rework fixes a few bugs:
+  The chat window is re-implemented from scratch. It is rebuilt using the MVC-principle, creating a clear separation between state, viewing the state and interacting with the state. This rework fixes a few bugs:
 
-- The chat window fully supports UI scaling.
-- The chat will always snap to the frame when you open it, making it impossible for the chat to be off-screen after a resolution change.
+  - The chat window fully supports UI scaling.
+  - The chat will always snap to the frame when you open it, making it impossible for the chat to be off-screen after a resolution change.
 
-Adds a few features:
+  Adds a few features:
 
-- You can now issue various chat commands, use `/help` to learn more.
-- UI mods can add chat commands with ease.
-- Autocomplete on names when you start with `@`.
-- Convenient for the simulation (campaign, AIs, events) to send chat messages.
-- Click on a chat message to copy it to clipboard.
+  - You can now issue various chat commands, use `/help` to learn more.
+  - UI mods can add chat commands with ease.
+  - Autocomplete on names when you start with `@`.
+  - Convenient for the simulation (campaign, AIs, events) to send chat messages.
+  - Click on a chat message to copy it to clipboard.
 
-And finally there are a few quirks:
+  And finally there are a few quirks:
 
-- The chat now starts bottom-up, instead of top-down.
+  - The chat now starts bottom-up, instead of top-down.

--- a/changelog/snippets/other.7202.md
+++ b/changelog/snippets/other.7202.md
@@ -1,0 +1,1 @@
+- Fix unit icons not loading on the changelog website (#7202).

--- a/docs/_plugins/balance_change.rb
+++ b/docs/_plugins/balance_change.rb
@@ -9,7 +9,13 @@ Jekyll::Hooks.register [:pages, :documents], :post_render do |doc|
 
   next unless apply
 
-  # Use https://regex101.com/ to debug regex.
+  # This regex takes the generated html and applies the necessary css classes to
+  # balance changes. We search for item lists with the characteristic formatting,
+  # ending with a colon in the first line and having an arrow (-&gt; in html) in
+  # the second. This is specific enough to not accidentally catch normal text or
+  # itemized lists.
+  # The unit icon and title is handled by balance_change.rb.
+  # Use https://regex101.com/ to debug the regex.
   doc.output.gsub!(
     /<li>([^<]+?)<ul>\s*<li>([^<]+?:\s)([^<]+)\s-&gt;\s([^<]+)<\/li>/,
     '<li><span class="change-category">\1</span><ul> <li><span class="change">\2</span><span class="old">\3</span> → <span class="new">\4</span></li>'

--- a/docs/_plugins/balance_change.rb
+++ b/docs/_plugins/balance_change.rb
@@ -14,7 +14,7 @@ Jekyll::Hooks.register [:pages, :documents], :post_render do |doc|
   # ending with a colon in the first line and having an arrow (-&gt; in html) in
   # the second. This is specific enough to not accidentally catch normal text or
   # itemized lists.
-  # The unit icon and title is handled by balance_change.rb.
+  # The unit icon and title is handled by unit_block.rb.
   # Use https://regex101.com/ to debug the regex.
   doc.output.gsub!(
     /<li>([^<]+?)<ul>\s*<li>([^<]+?:\s)([^<]+)\s-&gt;\s([^<]+)<\/li>/,

--- a/docs/_plugins/unit_block.rb
+++ b/docs/_plugins/unit_block.rb
@@ -30,7 +30,7 @@ module Jekyll
       <<~HTML
       <div class="unit-header">
         <img class="unit-icon"
-             src="/assets/icons/#{icon_name}">
+             src="../assets/icons/#{icon_name}">
         <span class="unit-name">#{name}</span>
       </div>
       HTML

--- a/docs/development-changelog/balance-snippet.md
+++ b/docs/development-changelog/balance-snippet.md
@@ -11,23 +11,22 @@ The snippet file should be named `balance.<PR Number>.md`.
 
 ```md
 {% unit <BlueprintID> %}
-<Formatted Unit Name>
+<Title>
 {% endunit %}
-<Description> (#<PR Number>)
+<Description> (#<PR Number>).
 - <Category>:
   - <Parameter Name>: <value before> -> <value after>
 ```
 
-- PR Number: The number of the pull request on GitHub.
-- Description: A 1-sentence summary of the changes and then a short explanation behind the reasoning for the changes.
-- Formatted Unit Name: `<UnitName>: <Tech> <Unit Role>` For example: `Exodus: T2 Destroyer`. This is similar to the format visible in unit dbs and the in-game UI when hovering over a unit.
-- Blueprint ID: Blueprint ID of the unit. If the change is an enhancement, the Blueprint ID is enhancements/faction/name. You can find out the correct name by looking into the [enhancements icon folder](https://github.com/FAForever/fa/tree/develop/docs/assets/icons/enhancements).
+- Description: A summary of the changes and/or an explanation behind the reasoning for the changes.
+- PR Number: The number of the pull request on GitHub. Make sure that the dot of the last sentence comes after this.
+- Title: Usually `<UnitName>: <Tech> <Unit Role>` For example: `Exodus: T2 Destroyer`. This is similar to the format visible in unit dbs and the in-game UI when hovering over a unit. When the same change has been applied to multiple units, you can just write the group in the title. The BlueprintID loads the unit icon, so choose a unit that is most representative. (UEF when all factions are affected).
+- BlueprintID: Blueprint ID of the unit. If the change is an enhancement, the Blueprint ID is enhancements/faction/name. You can find out the correct name by looking into the [enhancements icon folder](https://github.com/FAForever/fa/tree/develop/docs/assets/icons/enhancements).
 - Category: A subheader to categorize parameters. Usually a blueprint subtable name (ex: Physics) or a weapon name.
 - Parameter Name: The name for the value that was changed. It doesn't need to be the exact blueprint field name; it should be a name that players can understand.
 - Value before/after: The value before/after the change. If relevant, derived values like DPS can be put in parentheses after the value as such: `<damage> (<dps>) -> <damage> (<dps>)`.
 
-When the same change has been applied to multiple units, you can just write the group in the title. The unitID still loads the unit icon, so choose a unit that is most representative. (UEF when all factions are affected).
-Alternatively, or when a balance change affects multiple units in different ways, you can also put the description text first and then list the affected units with their changed stats.
+This formatting allows automatic styling of the changes on the website, but it actually consists of independent parts. You can insert additional description text after the parameter change lines, just make sure to leave a blank line. When a balance change affects multiple units in different ways, you can also put the description text first and then insert the affected units with their changed stats.
 
 ### Example snippets
 
@@ -57,4 +56,28 @@ Further increase the MuzzleSalvoSize of the Cybran ACU's Nanite Torpedo upgrade 
 - Torpedo weapon:
     - Damage (DPS): 60 (225) -> 45 (225)
     - Muzzle Salvo Size: 3 -> 4
+```
+```md
+{% unit XEB2402 %}
+Novax Center: Experimental Satellite System
+{% endunit %}
+Reduce Novax's ability to kill many shields, T2 fabs, and engineers in a single volley, and rebalance its costs to make it more vulnerable to artillery fire, especially when built in large numbers (#7123).
+- Defense Satellite's Orbital Death Laser:
+  - Beam Lifetime: 8.1s -> 5.4s
+  - Damage: 60 (4860 per volley) -> 90 (4860 per volley)
+  - Damage Radius: 1 -> 0.5
+  - Aim Speed: 360 deg/s -> 8 deg/s
+  - Charge cost: 0 E -> 72000 E (3750 E/s average)
+  - Charge drain rate: 0 E -> 5000 E/s
+- Base Station:
+  - Mass cost: 36000 -> 32000
+  - Energy cost: 512000 -> 800000
+  - Build time: 44800 -> 43600
+
+The build cost is reduced by the cost of power generators (with storage adjacency) required to power the satellite's firing cost. The energy cost is increased to guide players towards building the power required for firing before building the Novax.
+
+Remove Omni from the Novax as it unnecessarily counters cloak which is already more than sufficiently countered by T3 Omni radars. Since Omni can detect underwater units, sonar is added to partially keep that interaction. (#7123)
+- Defense Satellite:
+  - Omni radius: 60 -> 0
+  - Sonar radius: 0 -> 60
 ```

--- a/docs/development-changelog/balance-snippet.md
+++ b/docs/development-changelog/balance-snippet.md
@@ -26,7 +26,7 @@ The snippet file should be named `balance.<PR Number>.md`.
 - Parameter Name: The name for the value that was changed. It doesn't need to be the exact blueprint field name; it should be a name that players can understand.
 - Value before/after: The value before/after the change. If relevant, derived values like DPS can be put in parentheses after the value as such: `<damage> (<dps>) -> <damage> (<dps>)`.
 
-This formatting allows automatic styling of the changes on the website, but it actually consists of independent parts. You can insert additional description text after the parameter change lines, just make sure to leave a blank line. When a balance change affects multiple units in different ways, you can also put the description text first and then insert the affected units with their changed stats.
+This formatting allows automatic styling of the changes on the website, but it actually consists of independent parts. You can insert additional description text after the parameter change lines, just make sure to leave a blank line so that the text starts on a new line. When a balance change affects multiple units in different ways, you can also put the description text first and then insert the affected units with their changed stats.
 
 ### Example snippets
 


### PR DESCRIPTION
## Description of the proposed changes
The unit icons for the balance changelog had a broken url, so they didn't load. See: https://faforever.github.io/fa/changelog/fafdevelop
While fixing this I also improved the documentation a little.


## Testing done on the proposed changes
In the local environment the images still work, so hopefully they will now also work once we deploy the changes.


## Additional context
@lL1l1 can you convert the rest of the balance snippets to the new format? I started doing it, but then I realized there is more important stuff that I should attend to and if I do it then other people don't learn to use the new format.
There are also non-balance snippets that still have the PR number at the start. Could you change these also? Most of them are yours anyway. You can just make a PR with all the changed snippets, then I will review it quickly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Balance Updates**
  * Reduced the Loyalist T3 Siege Assault Bot’s stun duration against T1/T2 mobile units.
  * Adjusted Novax orbital laser behavior, costs, energy drain, base-station costs, and build time.
  * Replaced Novax Omni detection with sonar.

* **Bug Fixes**
  * Fixed missing unit icons on the changelog website.

* **Documentation**
  * Updated quick load hotkey and chat window feature documentation.
  * Improved balance change templates and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->