### PR TITLE
Use new format for the balance snippets

### DIFF
--- a/changelog/snippets/balance.7141.md
+++ b/changelog/snippets/balance.7141.md
@@ -10,7 +10,9 @@
 
   Combatant and Rambo presets are separated by a high energy cost difference and Rambos get a mass cost reduction. This allows combatants to help with a faction's early issues, while Rambos play a role in the late game by being efficient but high infrastructure cost combat units, and highly versatile engineering units that can mitigate the dominance of air and the risk of reclaim donations.
 
-  - **Quantum Gateways (UAB0304, UEB0304, URB0304, XSB0304)**
+{% unit UAB0304 %}
+Quantum Gateways
+{% endunit %}
     - Mass cost: 3000 -> 2550
     - Energy cost: 30000 -> 25500
     - Build rate: 120 -> 160
@@ -19,7 +21,9 @@
       - Energy discount from T1 and T3 pgens: 0.25% and 5% -> 1.563% and 15.62%
       - Mass discount from T2 and T3 mass fabs: 0.75% and 3.75% -> 1.25% and 20%
 
-  - **Aeon Support Armored Command Unit (UAL0301)**
+{% unit UAL0301 %}
+Aeon Support Armored Command Unit
+{% endunit %}
     - Mass cost: 1950 -> 1550
     - Energy cost: 27100 -> 21500
     - Build time: 14400 -> 8250
@@ -52,7 +56,9 @@
     - Nano-Repair System:
       - Energy cost: 74000 -> 57500
 
-  - **UEF Support Armored Command Unit (UEL0301)**
+{% unit UEL0301 %}
+UEF Support Armored Command Unit
+{% endunit %}
     - Mass: 2100 -> 1700
     - Energy: 25200 -> 20400
     - Build time: 14400 -> 9060
@@ -95,7 +101,9 @@
     - Enhanced Sensor System:
       - Build time: 3000 -> 2520
 
-  - **Cybran Support Armored Command Unit (URL0301)**
+{% unit URL0301 %}
+Cybran Support Armored Command Unit
+{% endunit %}
     - Mass: 2000 -> 1600
     - Energy: 26400 -> 21100
     - Build time: 14400 -> 8530
@@ -138,7 +146,9 @@
       - Build time: 1800 -> 1620
       - Energy maintenance cost: 100 -> 70
 
-  - **Seraphim Support Armored Command Unit (XSL0301)**
+{% unit XSL0301 %}
+Seraphim Support Armored Command Unit
+{% endunit %}
     - Mass: 2400 -> 1650
     - Energy: 30200 -> 20800
     - Build time: 14400 -> 8800

--- a/changelog/snippets/balance.7141.md
+++ b/changelog/snippets/balance.7141.md
@@ -1,4 +1,4 @@
-- (#7141, #7164) Make SACUs easier to access with reduced infrastructure costs and make them more powerful with a general cost reduction for SACUs and targeted adjustments for weaker upgrades (engineering upgrades, UEF bubble shield, Seraphim Overcharge).
+- Make SACUs easier to access with reduced infrastructure costs and make them more powerful with a general cost reduction for SACUs and targeted adjustments for weaker upgrades (engineering upgrades, UEF bubble shield, Seraphim Overcharge) (#7141, #7164).
 
   Seraphim Shield is moved to the right arm to nerf Seraphim teleport SACUs and enable a more useful Rambo preset. 
 

--- a/changelog/snippets/balance.7141.md
+++ b/changelog/snippets/balance.7141.md
@@ -1,199 +1,199 @@
 - Make SACUs easier to access with reduced infrastructure costs and make them more powerful with a general cost reduction for SACUs and targeted adjustments for weaker upgrades (engineering upgrades, UEF bubble shield, Seraphim Overcharge) (#7141, #7164).
 
-  Seraphim Shield is moved to the right arm to nerf Seraphim teleport SACUs and enable a more useful Rambo preset. 
+Seraphim Shield is moved to the right arm to nerf Seraphim teleport SACUs and enable a more useful Rambo preset. 
 
-  Seraphim receives a RAS upgrade instead of its higher base cost and base production.
+Seraphim receives a RAS upgrade instead of its higher base cost and base production.
 
-  Since they're easier to rush and are more powerful, SACUs have their ACU target priority ability removed to allow overcharge to counter early SACUs again.
+Since they're easier to rush and are more powerful, SACUs have their ACU target priority ability removed to allow overcharge to counter early SACUs again.
 
-  Due to costing less, the buildpower of non-UEF SACUs is reduced (engi presets keep their buildpower). UEF keeps their buildpower because they have a weaker engineer preset, the most expensive base SACU, a T4 that struggles with pushing, and unique ravagers.
+Due to costing less, the buildpower of non-UEF SACUs is reduced (engi presets keep their buildpower). UEF keeps their buildpower because they have a weaker engineer preset, the most expensive base SACU, a T4 that struggles with pushing, and unique ravagers.
 
-  Combatant and Rambo presets are separated by a high energy cost difference and Rambos get a mass cost reduction. This allows combatants to help with a faction's early issues, while Rambos play a role in the late game by being efficient but high infrastructure cost combat units, and highly versatile engineering units that can mitigate the dominance of air and the risk of reclaim donations.
+Combatant and Rambo presets are separated by a high energy cost difference and Rambos get a mass cost reduction. This allows combatants to help with a faction's early issues, while Rambos play a role in the late game by being efficient but high infrastructure cost combat units, and highly versatile engineering units that can mitigate the dominance of air and the risk of reclaim donations.
 
 {% unit UAB0304 %}
 Quantum Gateways
 {% endunit %}
-    - Mass cost: 3000 -> 2550
-    - Energy cost: 30000 -> 25500
-    - Build rate: 120 -> 160
-    - Health: 10000 -> 7500
-    - Adjacency:
-      - Energy discount from T1 and T3 pgens: 0.25% and 5% -> 1.563% and 15.62%
-      - Mass discount from T2 and T3 mass fabs: 0.75% and 3.75% -> 1.25% and 20%
+- Mass cost: 3000 -> 2550
+- Energy cost: 30000 -> 25500
+- Build rate: 120 -> 160
+- Health: 10000 -> 7500
+- Adjacency:
+  - Energy discount from T1 and T3 pgens: 0.25% and 5% -> 1.563% and 15.62%
+  - Mass discount from T2 and T3 mass fabs: 0.75% and 3.75% -> 1.25% and 20%
 
 {% unit UAL0301 %}
 Aeon Support Armored Command Unit
 {% endunit %}
-    - Mass cost: 1950 -> 1550
-    - Energy cost: 27100 -> 21500
-    - Build time: 14400 -> 8250
-    - Buildpower: 56 -> 42
-    - Removed ability to prioritize ACUs
-    - Rapid Fabricator:
-      - Mass cost: 800 -> 500
-      - Energy cost: 50500 -> 10100
-      - Build time: 4200 -> 1350
-      - Added buildpower: +42 -> +56
-    - Resource Allocation System:
-      
-      Cost increased to keep requirements for sacrifice the same and to slightly counteract the base cost and quantum gateway buildpower/adjacency buffs.
+- Mass cost: 1950 -> 1550
+- Energy cost: 27100 -> 21500
+- Build time: 14400 -> 8250
+- Buildpower: 56 -> 42
+- Removed ability to prioritize ACUs
+- Rapid Fabricator:
+  - Mass cost: 800 -> 500
+  - Energy cost: 50500 -> 10100
+  - Build time: 4200 -> 1350
+  - Added buildpower: +42 -> +56
+- Resource Allocation System:
+  
+  Cost increased to keep requirements for sacrifice the same and to slightly counteract the base cost and quantum gateway buildpower/adjacency buffs.
 
-      - Mass cost: 4500 -> 4600
-      - Energy cost: 90000 -> 94400 
-      - Build time: 8400 -> 20550
-    - Personal Shield Generator:
-      - Energy cost: 64950 -> 49000
-      - Build time: 5040 -> 4950
-      - Energy maintenance cost: 300 -> 210
-    - Heavy Personal Shield Generator:
-      - Mass cost: 1800 -> 900
-      - Energy cost: 100000 -> 200975
-      - Build time: 7000 -> 3660
-      - Energy maintenance cost: 600 -> 420
-    - Reacton Refractor (Range and AoE upgrade):
-      - Energy cost: 46200 -> 45600
-      - Build time: 6048 -> 6200
-    - Nano-Repair System:
-      - Energy cost: 74000 -> 57500
+  - Mass cost: 4500 -> 4600
+  - Energy cost: 90000 -> 94400 
+  - Build time: 8400 -> 20550
+- Personal Shield Generator:
+  - Energy cost: 64950 -> 49000
+  - Build time: 5040 -> 4950
+  - Energy maintenance cost: 300 -> 210
+- Heavy Personal Shield Generator:
+  - Mass cost: 1800 -> 900
+  - Energy cost: 100000 -> 200975
+  - Build time: 7000 -> 3660
+  - Energy maintenance cost: 600 -> 420
+- Reacton Refractor (Range and AoE upgrade):
+  - Energy cost: 46200 -> 45600
+  - Build time: 6048 -> 6200
+- Nano-Repair System:
+  - Energy cost: 74000 -> 57500
 
 {% unit UEL0301 %}
 UEF Support Armored Command Unit
 {% endunit %}
-    - Mass: 2100 -> 1700
-    - Energy: 25200 -> 20400
-    - Build time: 14400 -> 9060
-    - Removed ability to prioritize ACUs
-    - Shield Generator Field:
+- Mass: 2100 -> 1700
+- Energy: 25200 -> 20400
+- Build time: 14400 -> 9060
+- Removed ability to prioritize ACUs
+- Shield Generator Field:
 
-      The UEF bubble shield is heavily reduced in cost by removing its prerequisite, and its stats are adjusted to be closer to mobile shields.
+  The UEF bubble shield is heavily reduced in cost by removing its prerequisite, and its stats are adjusted to be closer to mobile shields.
 
-      - Prerequisite: Personal Shield Generator -> None
-      - Mass cost: 3500 -> 3300
-      - Energy cost: 360800 -> 244700
-      - Build time: 10800 -> 14500
-      - Energy maintenance cost: 1000 -> 700
-      - Shield stats:
-        - Health: 52000 -> 22000
-        - Recharge Time: 215 -> 100 seconds
-        - Regen Rate: 150 -> 160 hp/s
-        - Regen Delay: 1 -> 3 seconds
-        - Spillover mult: 0.2 -> 0.3
-    - C-D3 Engineering Drone:
-      - Energy cost: 8700 -> 7700
-      - Build time: 2500 -> 1000
-    - Resource Allocation System:
-      - Mass cost: 4500 -> 4600
-      - Energy cost: 90000 -> 94400 
-      - Build time: 8400 -> 20550
-    - Personal Shield Generator:
-      - Mass cost: 2000 -> 1700
-      - Energy cost: 100200 -> 289000
-      - Build time: 7200 -> 6950
-      - Energy maintenance cost: 500 -> 350
-    - Energy Accelerator (Fire Rate upgrade):
-      - Energy cost: 44700 -> 43900
-      - Build time: 5040 -> 5060
-    - Heavy Plasma Refractor (Range and AoE upgrade):
-      - Energy cost: 30000 -> 28600
-      - Build time: 3360 -> 3370
-    - Radar Jammer:
-      - Build time: 2500 -> 1000
-    - Enhanced Sensor System:
-      - Build time: 3000 -> 2520
+  - Prerequisite: Personal Shield Generator -> None
+  - Mass cost: 3500 -> 3300
+  - Energy cost: 360800 -> 244700
+  - Build time: 10800 -> 14500
+  - Energy maintenance cost: 1000 -> 700
+  - Shield stats:
+    - Health: 52000 -> 22000
+    - Recharge Time: 215 -> 100 seconds
+    - Regen Rate: 150 -> 160 hp/s
+    - Regen Delay: 1 -> 3 seconds
+    - Spillover mult: 0.2 -> 0.3
+- C-D3 Engineering Drone:
+  - Energy cost: 8700 -> 7700
+  - Build time: 2500 -> 1000
+- Resource Allocation System:
+  - Mass cost: 4500 -> 4600
+  - Energy cost: 90000 -> 94400 
+  - Build time: 8400 -> 20550
+- Personal Shield Generator:
+  - Mass cost: 2000 -> 1700
+  - Energy cost: 100200 -> 289000
+  - Build time: 7200 -> 6950
+  - Energy maintenance cost: 500 -> 350
+- Energy Accelerator (Fire Rate upgrade):
+  - Energy cost: 44700 -> 43900
+  - Build time: 5040 -> 5060
+- Heavy Plasma Refractor (Range and AoE upgrade):
+  - Energy cost: 30000 -> 28600
+  - Build time: 3360 -> 3370
+- Radar Jammer:
+  - Build time: 2500 -> 1000
+- Enhanced Sensor System:
+  - Build time: 3000 -> 2520
 
 {% unit URL0301 %}
 Cybran Support Armored Command Unit
 {% endunit %}
-    - Mass: 2000 -> 1600
-    - Energy: 26400 -> 21100
-    - Build time: 14400 -> 8530
-    - Buildpower: 56 -> 42
-    - Removed ability to prioritize ACUs
-    - Rapid Fabricator:
-      - Mass cost: 800 -> 500
-      - Energy cost: 51100 -> 10100
-      - Build time: 4200 -> 1350
-      - Added buildpower: +42 -> +56
-    - Resource Allocation System:
-      - Mass cost: 4500 -> 4600
-      - Energy cost: 90000 -> 94400 
-      - Build time: 8400 -> 20550
-    - Disintegrator Amplifier (Damage and Range upgrade):
+- Mass: 2000 -> 1600
+- Energy: 26400 -> 21100
+- Build time: 14400 -> 8530
+- Buildpower: 56 -> 42
+- Removed ability to prioritize ACUs
+- Rapid Fabricator:
+  - Mass cost: 800 -> 500
+  - Energy cost: 51100 -> 10100
+  - Build time: 4200 -> 1350
+  - Added buildpower: +42 -> +56
+- Resource Allocation System:
+  - Mass cost: 4500 -> 4600
+  - Energy cost: 90000 -> 94400 
+  - Build time: 8400 -> 20550
+- Disintegrator Amplifier (Damage and Range upgrade):
 
-      Due to the SACU cost reduction making SACUs upgraded with only this gun upgrade overpowered, mass costs from EMP, Nano, and Cloaking are moved to this upgrade.
+  Due to the SACU cost reduction making SACUs upgraded with only this gun upgrade overpowered, mass costs from EMP, Nano, and Cloaking are moved to this upgrade.
 
-      - Mass cost: 800 -> 1400
-      - Energy cost: 24000 -> 50100
-      - Build time: 3000 -> 6950
-    - Personal Cloaking Generator:
-      - Mass cost: 5000 -> 2000
-      - Energy cost: 382200 -> 312700 
-      - Build time: 13800 -> 8300
-      - Health bonus: 15000 -> 17000
-      - Energy maintenance cost: 3500 -> 2500
-    - EMP Burst:
-      - Mass cost: 1000 -> 700
-      - Energy cost: 60000 -> 32500 
-      - Build time: 3600 -> 3000
-    - Nanite Missile System:
-      - Build time: 3000 -> 2750
-    - Nano-Repair System:
-      - Mass cost: 2200 -> 1900
-      - Energy cost: 103500 -> 92300 
-      - Build time: 6000 -> 7850
-    - Personal Stealth Generator:
-      - Energy cost: 7400 -> 13000
-      - Build time: 1800 -> 1620
-      - Energy maintenance cost: 100 -> 70
+  - Mass cost: 800 -> 1400
+  - Energy cost: 24000 -> 50100
+  - Build time: 3000 -> 6950
+- Personal Cloaking Generator:
+  - Mass cost: 5000 -> 2000
+  - Energy cost: 382200 -> 312700 
+  - Build time: 13800 -> 8300
+  - Health bonus: 15000 -> 17000
+  - Energy maintenance cost: 3500 -> 2500
+- EMP Burst:
+  - Mass cost: 1000 -> 700
+  - Energy cost: 60000 -> 32500 
+  - Build time: 3600 -> 3000
+- Nanite Missile System:
+  - Build time: 3000 -> 2750
+- Nano-Repair System:
+  - Mass cost: 2200 -> 1900
+  - Energy cost: 103500 -> 92300 
+  - Build time: 6000 -> 7850
+- Personal Stealth Generator:
+  - Energy cost: 7400 -> 13000
+  - Build time: 1800 -> 1620
+  - Energy maintenance cost: 100 -> 70
 
 {% unit XSL0301 %}
 Seraphim Support Armored Command Unit
 {% endunit %}
-    - Mass: 2400 -> 1650
-    - Energy: 30200 -> 20800
-    - Build time: 14400 -> 8800
-    - Buildpower: 56 -> 42
-    - Removed ability to prioritize ACUs
-    - Mass production: 3 -> 1
-    - Energy production: 300 -> 20
-    - Added Resource Allocation System:
+- Mass: 2400 -> 1650
+- Energy: 30200 -> 20800
+- Build time: 14400 -> 8800
+- Buildpower: 56 -> 42
+- Removed ability to prioritize ACUs
+- Mass production: 3 -> 1
+- Energy production: 300 -> 20
+- Added Resource Allocation System:
 
-        Seraphim players have continued to struggle with the ability to build a mobile economy because the stats were balanced around the high buildpower of Seraphim SACU spam compared to other factions' RAS SACUs. Since players aren't using this, the RAS upgrade is replacing the SACU's increased base production and base cost.
+    Seraphim players have continued to struggle with the ability to build a mobile economy because the stats were balanced around the high buildpower of Seraphim SACU spam compared to other factions' RAS SACUs. Since players aren't using this, the RAS upgrade is replacing the SACU's increased base production and base cost.
 
-      - Slot: Right arm (teleport and overcharge arm)
-      - Mass cost: 4600
-      - Energy cost: 94400 
-      - Build time: 20550
-      - Mass production: 10
-      - Energy production: 1000
-    - Rapid Fabricator:
-      - Mass cost: 450 -> 500
-      - Energy cost: 47400 -> 10100
-      - Build time: 4200 -> 1350
-      - Added buildpower: +42 -> +56
-    - Nano-Repair System:
-      - Mass cost: 2300 -> 2500
-      - Energy cost: 74300 -> 141200 
-      - Build time: 5900 -> 11650
-    - Tactical Missile Launcher:
-      - Mass cost: 1500 -> 1800
-      - Energy cost: 46000 -> 68000 
-      - Build time: 4200 -> 8450
-    - Overcharge:
-      - Mass cost: 4500 -> 3000
-      - Energy cost: 283500 -> 155000 
-      - Build time: 12600 -> 13800
-    - Personal Shield Generator:
+  - Slot: Right arm (teleport and overcharge arm)
+  - Mass cost: 4600
+  - Energy cost: 94400 
+  - Build time: 20550
+  - Mass production: 10
+  - Energy production: 1000
+- Rapid Fabricator:
+  - Mass cost: 450 -> 500
+  - Energy cost: 47400 -> 10100
+  - Build time: 4200 -> 1350
+  - Added buildpower: +42 -> +56
+- Nano-Repair System:
+  - Mass cost: 2300 -> 2500
+  - Energy cost: 74300 -> 141200 
+  - Build time: 5900 -> 11650
+- Tactical Missile Launcher:
+  - Mass cost: 1500 -> 1800
+  - Energy cost: 46000 -> 68000 
+  - Build time: 4200 -> 8450
+- Overcharge:
+  - Mass cost: 4500 -> 3000
+  - Energy cost: 283500 -> 155000 
+  - Build time: 12600 -> 13800
+- Personal Shield Generator:
 
-      The shield generator is being moved to the right arm to nerf teleport and enable a more useful Rambo preset.
+  The shield generator is being moved to the right arm to nerf teleport and enable a more useful Rambo preset.
 
-      Seraphim Teleport SACUs were extremely strong for their 20k mass cost (with ~18k energy infrastructure cost): they were harder to stop from killing an SMD than a telemazer (in terms of DPS/PD amount), their infrastructure is reusable, and the only way to stop multiple teleports on a far more expensive 75k mass artillery or 225k mass game ender is by spamming shields and hoping they got in between the SACU's gun and the target.
+  Seraphim Teleport SACUs were extremely strong for their 20k mass cost (with ~18k energy infrastructure cost): they were harder to stop from killing an SMD than a telemazer (in terms of DPS/PD amount), their infrastructure is reusable, and the only way to stop multiple teleports on a far more expensive 75k mass artillery or 225k mass game ender is by spamming shields and hoping they got in between the SACU's gun and the target.
 
-      The Rambo preset is changed from Nano + Shield + Overcharge to Nano + Shield + Sensors/Gun Range. It can act as a lategame HP tank that doesn't rely on energy for DPS like the Advanced Combatant preset or regen for survivability like the Nano Combatant preset.
+  The Rambo preset is changed from Nano + Shield + Overcharge to Nano + Shield + Sensors/Gun Range. It can act as a lategame HP tank that doesn't rely on energy for DPS like the Advanced Combatant preset or regen for survivability like the Nano Combatant preset.
 
 
-      - Slot: Back (TML and sensors/gun range) -> Right arm (teleport and overcharge)
-      - Mass cost: 1050 -> 1000
-      - Energy cost: 107500 -> 190000
-      - Build time: 6720 -> 4000
-      - Energy maintenance cost: 300 -> 210
+  - Slot: Back (TML and sensors/gun range) -> Right arm (teleport and overcharge)
+  - Mass cost: 1050 -> 1000
+  - Energy cost: 107500 -> 190000
+  - Build time: 6720 -> 4000
+  - Energy maintenance cost: 300 -> 210

--- a/changelog/snippets/balance.7143.md
+++ b/changelog/snippets/balance.7143.md
@@ -1,4 +1,4 @@
-- (#7143) Rebalance Fire Beetle with removed cloak to make it interactable outside of later T3 stage or in ACU fights.
+- Rebalance Fire Beetle with removed cloak to make it interactable outside of later T3 stage or in ACU fights (#7143).
 
 {% unit XRL0302 %}
 Fire Beetle: T2 Mobile Bomb

--- a/changelog/snippets/balance.7143.md
+++ b/changelog/snippets/balance.7143.md
@@ -2,7 +2,7 @@
 Fire Beetle: T2 Mobile Bomb
 {% endunit %}
 Rebalance Fire Beetle with removed cloak to make it interactable outside of later T3 stage or in ACU fights (#7143).
-  - Remove cloak and its associated upkeep and visual effects.
-  - Health: 500 -> 1340
-  - Regen rate: 0 -> 10
-  - Speed: 5 -> 3.8
+- Remove cloak and its associated upkeep and visual effects.
+- Health: 500 -> 1340
+- Regen rate: 0 -> 10
+- Speed: 5 -> 3.8

--- a/changelog/snippets/balance.7143.md
+++ b/changelog/snippets/balance.7143.md
@@ -1,6 +1,8 @@
 - (#7143) Rebalance Fire Beetle with removed cloak to make it interactable outside of later T3 stage or in ACU fights.
 
-  **Fire Beetle: T2 Mobile Bomb (XRL0302):**
+{% unit XRL0302 %}
+Fire Beetle: T2 Mobile Bomb
+{% endunit %}
   - Remove cloak and its associated upkeep and visual effects.
   - Health: 500 -> 1340
   - Regen rate: 0 -> 10

--- a/changelog/snippets/balance.7143.md
+++ b/changelog/snippets/balance.7143.md
@@ -1,8 +1,7 @@
-- Rebalance Fire Beetle with removed cloak to make it interactable outside of later T3 stage or in ACU fights (#7143).
-
 {% unit XRL0302 %}
 Fire Beetle: T2 Mobile Bomb
 {% endunit %}
+Rebalance Fire Beetle with removed cloak to make it interactable outside of later T3 stage or in ACU fights (#7143).
   - Remove cloak and its associated upkeep and visual effects.
   - Health: 500 -> 1340
   - Regen rate: 0 -> 10

--- a/changelog/snippets/balance.7146.md
+++ b/changelog/snippets/balance.7146.md
@@ -1,8 +1,7 @@
-- Rebalance Galactic Colossus's tractor claws so that the GC is weaker against T3 units by itself or when skirmishing but stronger with an army (#7146).
-
 {% unit UAL0401 %}
 Galactic Colossus: Experimental Assault Bot
 {% endunit %}
+Rebalance Galactic Colossus's tractor claws so that the GC is weaker against T3 units by itself or when skirmishing but stronger with an army (#7146).
   - Tractor Claws (x2)
     - DPS: 729 -> 240
     - Range: 41 -> 30

--- a/changelog/snippets/balance.7146.md
+++ b/changelog/snippets/balance.7146.md
@@ -1,4 +1,4 @@
-- (#7146) Rebalance Galactic Colossus's tractor claws so that the GC is weaker against T3 units by itself or when skirmishing but stronger with an army.
+- Rebalance Galactic Colossus's tractor claws so that the GC is weaker against T3 units by itself or when skirmishing but stronger with an army (#7146).
 
 {% unit UAL0401 %}
 Galactic Colossus: Experimental Assault Bot

--- a/changelog/snippets/balance.7146.md
+++ b/changelog/snippets/balance.7146.md
@@ -1,6 +1,8 @@
 - (#7146) Rebalance Galactic Colossus's tractor claws so that the GC is weaker against T3 units by itself or when skirmishing but stronger with an army.
 
-  **Galactic Colossus: Experimental Assault Bot (UAL0401)**
+{% unit UAL0401 %}
+Galactic Colossus: Experimental Assault Bot
+{% endunit %}
   - Tractor Claws (x2)
     - DPS: 729 -> 240
     - Range: 41 -> 30

--- a/changelog/snippets/balance.7146.md
+++ b/changelog/snippets/balance.7146.md
@@ -2,7 +2,7 @@
 Galactic Colossus: Experimental Assault Bot
 {% endunit %}
 Rebalance Galactic Colossus's tractor claws so that the GC is weaker against T3 units by itself or when skirmishing but stronger with an army (#7146).
-  - Tractor Claws (x2)
-    - DPS: 729 -> 240
-    - Range: 41 -> 30
-    - Enemy units attached to the claw can be targeted by allied units.
+- Tractor Claws (x2)
+  - DPS: 729 -> 240
+  - Range: 41 -> 30
+  - Enemy units attached to the claw can be targeted by allied units.

--- a/changelog/snippets/balance.7147.md
+++ b/changelog/snippets/balance.7147.md
@@ -2,8 +2,8 @@
 Scathis: Experimental Mobile Rapid-Fire Artillery
 {% endunit %}
 Increase Scathis accuracy and survivability so it can better compete against other enders (#7147).
-  - Health: 9000 -> 17000
-  - Regen: 0 -> 134
-  - Add stealth field with 24 radius and 400 e/s maintenance.
-  - Proton Artillery:
-    - Fixed spread radius: 70 -> 63 (approximately +23% dmg/area)
+- Health: 9000 -> 17000
+- Regen: 0 -> 134
+- Add stealth field with 24 radius and 400 e/s maintenance.
+- Proton Artillery:
+  - Fixed spread radius: 70 -> 63 (approximately +23% dmg/area)

--- a/changelog/snippets/balance.7147.md
+++ b/changelog/snippets/balance.7147.md
@@ -1,8 +1,7 @@
-- Increase Scathis accuracy and survivability so it can better compete against other enders (#7147).
-
 {% unit URL0401 %}
 Scathis: Experimental Mobile Rapid-Fire Artillery
 {% endunit %}
+Increase Scathis accuracy and survivability so it can better compete against other enders (#7147).
   - Health: 9000 -> 17000
   - Regen: 0 -> 134
   - Add stealth field with 24 radius and 400 e/s maintenance.

--- a/changelog/snippets/balance.7147.md
+++ b/changelog/snippets/balance.7147.md
@@ -1,4 +1,4 @@
-- (#7147) Increase Scathis accuracy and survivability so it can better compete against other enders.
+- Increase Scathis accuracy and survivability so it can better compete against other enders (#7147).
 
 {% unit URL0401 %}
 Scathis: Experimental Mobile Rapid-Fire Artillery

--- a/changelog/snippets/balance.7147.md
+++ b/changelog/snippets/balance.7147.md
@@ -1,6 +1,8 @@
 - (#7147) Increase Scathis accuracy and survivability so it can better compete against other enders.
 
-  **Scathis: Experimental Mobile Rapid-Fire Artillery (URL0401)**
+{% unit URL0401 %}
+Scathis: Experimental Mobile Rapid-Fire Artillery
+{% endunit %}
   - Health: 9000 -> 17000
   - Regen: 0 -> 134
   - Add stealth field with 24 radius and 400 e/s maintenance.

--- a/changelog/snippets/balance.7165.md
+++ b/changelog/snippets/balance.7165.md
@@ -1,4 +1,4 @@
-{% unit <xal0305> %}
+{% unit xal0305 %}
 All T3 Sniper Bots
 {% endunit %}
 Remove snipers' ability to prioritize ACUs. (#7165)

--- a/changelog/snippets/balance.7167.md
+++ b/changelog/snippets/balance.7167.md
@@ -4,13 +4,13 @@ T3 Sniper Bots
 Reduce the speed of sniper bots so that they cannot infinitely kite GC and Ythotha, and increase range as compensation. (#7167)
 
 - Sprite Striker: T3 Sniper Bot
-  - Max speed: 2.5 -> 2.3
-  - Heavy Disruptor Cannon:
-    - Range: 60 -> 65
+- Max speed: 2.5 -> 2.3
+- Heavy Disruptor Cannon:
+  - Range: 60 -> 65
 - Usha-Ah: T3 Sniper Bot
-  - Max speed: 2.3 -> 2.2
-  - Snipe mode speed: 1.74 -> 1.7
-  - Sih Energy Rifle:
-    - Range: 55 -> 60
-  - Sih Energy Rifle Sniper Mode:
-    - Range: 65 -> 70
+- Max speed: 2.3 -> 2.2
+- Snipe mode speed: 1.74 -> 1.7
+- Sih Energy Rifle:
+  - Range: 55 -> 60
+- Sih Energy Rifle Sniper Mode:
+  - Range: 65 -> 70

--- a/changelog/snippets/balance.7196.md
+++ b/changelog/snippets/balance.7196.md
@@ -1,4 +1,4 @@
-{% unit <UEA0304> %}
+{% unit UEA0304 %}
 T3 Strategic Bombers
 {% endunit %}
 Revert the lift factor change from the last strat bomber buff (#6535) to try to increase the reliability of bomb drops when the bomber flies over hills. A reduced lift factor makes aircraft move slower up and down. (#7196)

--- a/changelog/snippets/category.7204.md
+++ b/changelog/snippets/category.7204.md
@@ -1,1 +1,0 @@
-- Your explanation here... [Don't forget to change the category in the filename] (#7204).

--- a/changelog/snippets/category.7204.md
+++ b/changelog/snippets/category.7204.md
@@ -1,0 +1,1 @@
+- Your explanation here... [Don't forget to change the category in the filename] (#7204).

--- a/changelog/snippets/fix.6882.md
+++ b/changelog/snippets/fix.6882.md
@@ -1,1 +1,1 @@
-- (#6882) Fix the `ModWeapons` blueprint field adding weapons after dummy weapons, causing the unit weapon to incorrectly get the dummy weapon's blueprint for the new weapon.
+- Fix the `ModWeapons` blueprint field adding weapons after dummy weapons, causing the unit weapon to incorrectly get the dummy weapon's blueprint for the new weapon (#6882).

--- a/changelog/snippets/fix.7051.md
+++ b/changelog/snippets/fix.7051.md
@@ -1,1 +1,1 @@
-- (#7051) Fix a unit-transfer exploit that adds silo progress to nuke subs and the Seraphim battleship for free.
+- Fix a unit-transfer exploit that adds silo progress to nuke subs and the Seraphim battleship for free (#7051).

--- a/changelog/snippets/fix.7057.md
+++ b/changelog/snippets/fix.7057.md
@@ -1,1 +1,1 @@
-- (#7057) Remove game options of unused mods from game launch info to try to get live replays to work.
+- Remove game options of unused mods from game launch info to try to get live replays to work (#7057).

--- a/changelog/snippets/fix.7136.md
+++ b/changelog/snippets/fix.7136.md
@@ -1,4 +1,4 @@
-- (#7136) Change description of Seraphim AA units to match the other three factions' equivalent units
+- Change description of Seraphim AA units to match the other three factions' equivalent units (#7136).
 
   **Ialla: T1 Anti-Air Defense**
     - Description: Anti-Air Defense -> Anti-Air Turret

--- a/changelog/snippets/fix.7138.md
+++ b/changelog/snippets/fix.7138.md
@@ -1,1 +1,1 @@
-- (#7138) Fix default target priorities that use parentheses to enable richer category parsing using normal category parsing instead.
+- Fix default target priorities that use parentheses to enable richer category parsing using normal category parsing instead (#7138).

--- a/changelog/snippets/fix.7153.md
+++ b/changelog/snippets/fix.7153.md
@@ -1,1 +1,1 @@
-- (#7153) Add a delay before ACUs explode when their player disconnects. This should fix replays cutting off at the first disconnected player.
+- Add a delay before ACUs explode when their player disconnects. This should fix replays cutting off at the first disconnected player (#7153).

--- a/changelog/snippets/fix.7159.md
+++ b/changelog/snippets/fix.7159.md
@@ -1,1 +1,1 @@
-- (#7159) Fix mods that allow building units on water causing those units to not be buildable on land due to how the expected default of a missing `BuildOnLayerCaps` table interacts with blueprint merge.
+- Fix mods that allow building units on water causing those units to not be buildable on land due to how the expected default of a missing `BuildOnLayerCaps` table interacts with blueprint merge (#7159).

--- a/changelog/snippets/fix.7162.md
+++ b/changelog/snippets/fix.7162.md
@@ -1,1 +1,1 @@
-- (#7162) Fix transfer of units with manually built enhancements.
+- Fix transfer of units with manually built enhancements (#7162).

--- a/changelog/snippets/fix.7177.md
+++ b/changelog/snippets/fix.7177.md
@@ -1,1 +1,1 @@
-- (#7177) Fix non-number mod version numbers erroring in rule and session init (encountered with the AutoTML mod).
+- Fix non-number mod version numbers erroring in rule and session init (encountered with the AutoTML mod) (#7177).

--- a/changelog/snippets/fix.7178.md
+++ b/changelog/snippets/fix.7178.md
@@ -1,1 +1,1 @@
-- (#7178) Fix projectiles passing destroyed units as damage instigators instead of themselves.
+- Fix projectiles passing destroyed units as damage instigators instead of themselves (#7178).

--- a/changelog/snippets/other.6882.md
+++ b/changelog/snippets/other.6882.md
@@ -1,1 +1,1 @@
-- (#6882) Give a warning when non-dummy weapons are assigned dummy weapon blueprints because they are positioned after a dummy weapon blueprint in the `Weapon` table of the unit blueprint.
+- Give a warning when non-dummy weapons are assigned dummy weapon blueprints because they are positioned after a dummy weapon blueprint in the `Weapon` table of the unit blueprint (#6882).

--- a/changelog/snippets/other.7012.md
+++ b/changelog/snippets/other.7012.md
@@ -1,1 +1,1 @@
-- (#7012) Annotate states and fix annotation warnings in `DefaultProjectileWeapon.lua`.
+- Annotate states and fix annotation warnings in `DefaultProjectileWeapon.lua` (#7012).

--- a/changelog/snippets/other.7045.md
+++ b/changelog/snippets/other.7045.md
@@ -1,1 +1,1 @@
-- (#7045) Document engine-side details of `UnitWeapon:CanFire()`.
+- Document engine-side details of `UnitWeapon:CanFire()` (#7045).

--- a/changelog/snippets/other.7052.md
+++ b/changelog/snippets/other.7052.md
@@ -1,1 +1,1 @@
-- (#7052) Clean up code style and add annotations in `SelectedInfo.lua`.
+- Clean up code style and add annotations in `SelectedInfo.lua` (#7052).

--- a/changelog/snippets/other.7155.md
+++ b/changelog/snippets/other.7155.md
@@ -1,1 +1,1 @@
-- (#7155) Annotate `SetNavigatorPersonalPosMaxDistance` and check it exists before calling it.
+- Annotate `SetNavigatorPersonalPosMaxDistance` and check it exists before calling it (#7155).

--- a/changelog/snippets/other.7166.md
+++ b/changelog/snippets/other.7166.md
@@ -1,1 +1,1 @@
-- (#7166) Rename `CLAUDE.md` to `AGENTS.md` for cross-agent compatibility.
+- Rename `CLAUDE.md` to `AGENTS.md` for cross-agent compatibility (#7166).

--- a/changelog/snippets/other.7176.md
+++ b/changelog/snippets/other.7176.md
@@ -1,1 +1,1 @@
-- (#7176) Update the FA Lua plugin used alongside our vscode intellisense extension to exclude diagnostics coming from the base file when writing a mod's hook file.
+- Update the FA Lua plugin used alongside our vscode intellisense extension to exclude diagnostics coming from the base file when writing a mod's hook file (#7176).


### PR DESCRIPTION
## Description of the proposed changes
Migrates the snippets to the new format.
I didn't change the content of the snippets although I think the SACU snippet could be written better.

## Testing done on the proposed changes
I don't know how to preview the generated changelog html.

## Additional context
Requested from #7202
The commit descriptions include the regex I used, so I suggest reviewing by commit and checking the regex. It may also be interesting to process old changelogs with that regex.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
~~- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).~~
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Balance Changes**
  - Rebalanced SACU and Quantum Gateway costs, build times, production, upgrades, abilities, and prerequisites across all factions.
  - Adjusted several unit statistics, including Fire Beetle, Scathis, Tractor Claws, strategic bomber lift, and UEF bubble shields.
  - Added Seraphim Resource Allocation System and updated unit equipment.

- **Bug Fixes**
  - Fixed weapon blueprint assignment, silo-progress exploits, target priorities, unit transfers, mod version handling, projectile attribution, and replay termination issues.

- **Documentation**
  - Improved changelog formatting, clarity, and consistency across balance, fix, and tooling entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->