### PR TITLE
Give external factories a UI selection sound

### DIFF
--- a/changelog/snippets/category.7207.md
+++ b/changelog/snippets/category.7207.md
@@ -1,0 +1,1 @@
+- Your explanation here... [Don't forget to change the category in the filename] (#7207).

--- a/changelog/snippets/category.7207.md
+++ b/changelog/snippets/category.7207.md
@@ -1,1 +1,0 @@
-- Your explanation here... [Don't forget to change the category in the filename] (#7207).

--- a/changelog/snippets/features.7207.md
+++ b/changelog/snippets/features.7207.md
@@ -1,0 +1,1 @@
+- Give external factories their respective factory's UI selection sound (#7207).

--- a/engine/Core/Blueprints/UnitBlueprint.lua
+++ b/engine/Core/Blueprints/UnitBlueprint.lua
@@ -807,6 +807,7 @@
 ---@field SelectionMeshScaleY? number
 ---@field SelectionMeshScaleZ? number
 ---@field UniformScale? number
+---@field UISelection? SoundHandle
 
 ---@class UnitBlueprintEnhancements : table<Enhancement, UnitBlueprintEnhancement>
 ---@field Slots table<EnhancementSlot, {name: UnlocalizedString, x: number, y: number}>

--- a/lua/system/blueprints-units.lua
+++ b/lua/system/blueprints-units.lua
@@ -693,6 +693,7 @@ function PostProcessUnitWithExternalFactory(allBlueprints, unit)
         efBlueprint.SelectionMeshScaleY = unit.ExternalFactory.SelectionMeshScaleY or 3
         efBlueprint.SelectionMeshScaleZ = unit.ExternalFactory.SelectionMeshScaleZ or 1
         efBlueprint.Display.UniformScale = unit.ExternalFactory.UniformScale or 1.6
+        efBlueprint.Audio = { UISelection = unit.ExternalFactory.UISelection or unit.Audio.UISelection }
 
         -- add our select button override
         if not efBlueprint.General.OrderOverrides then

--- a/units/UAA0310/UAA0310_unit.bp
+++ b/units/UAA0310/UAA0310_unit.bp
@@ -147,6 +147,7 @@ UnitBlueprint{
         SelectionCenterOffsetZ = -2,
         SelectionSizeX = 4,
         SelectionSizeZ = 4,
+        UISelection = Sound { Bank = 'Interface', Cue = 'Aeon_Select_Factory', LodCutoff = 'UnitMove_LodCutoff' },
     },
     Footprint = {
         MaxSlope = 0.25,

--- a/units/UAS0303/UAS0303_unit.bp
+++ b/units/UAS0303/UAS0303_unit.bp
@@ -135,6 +135,7 @@ UnitBlueprint{
         SelectionCenterOffsetZ = 8.5,
         SelectionSizeX = 4,
         SelectionSizeZ = 2,
+        UISelection = Sound { Bank = 'Interface', Cue = 'Aeon_Select_Factory', LodCutoff = 'UnitMove_LodCutoff' },
     },
     Footprint = {
         SizeX = 5,

--- a/units/UAS0401/UAS0401_unit.bp
+++ b/units/UAS0401/UAS0401_unit.bp
@@ -194,6 +194,7 @@ UnitBlueprint{
         SelectionCenterOffsetZ = 4,
         SelectionSizeX = 3,
         SelectionSizeZ = 3,
+        UISelection = Sound { Bank = 'Interface', Cue = 'Aeon_Select_Factory', LodCutoff = 'UnitMove_LodCutoff' },
     },
     General = {
         CommandCaps = {

--- a/units/UEL0401/UEL0401_unit.bp
+++ b/units/UEL0401/UEL0401_unit.bp
@@ -238,6 +238,7 @@ UnitBlueprint{
         SelectionCenterOffsetZ = 2.5,
         SelectionSizeX = 2,
         SelectionSizeZ = 2,
+        UISelection = Sound { Bank = 'Interface', Cue = 'UEF_Select_Factory', LodCutoff = 'UnitMove_LodCutoff' },
     },
     General = {
         BuildBones = {

--- a/units/UES0401/UES0401_unit.bp
+++ b/units/UES0401/UES0401_unit.bp
@@ -217,6 +217,7 @@ UnitBlueprint{
         SelectionCenterOffsetZ = 8,
         SelectionSizeX = 1,
         SelectionSizeZ = 4.5,
+        UISelection = Sound { Bank = 'Interface', Cue = 'UEF_Select_Factory', LodCutoff = 'UnitMove_LodCutoff' },
     },
     Footprint = {
         SizeX = 6,

--- a/units/URS0303/URS0303_unit.bp
+++ b/units/URS0303/URS0303_unit.bp
@@ -135,6 +135,7 @@ UnitBlueprint{
         SelectionCenterOffsetZ = 12,
         SelectionSizeX = 2,
         SelectionSizeZ = 4,
+        UISelection = Sound { Bank = 'Interface', Cue = 'Cybran_Select_Factory', LodCutoff = 'UnitMove_LodCutoff' },
     },
     Footprint = {
         SizeX = 5,

--- a/units/XSS0303/XSS0303_unit.bp
+++ b/units/XSS0303/XSS0303_unit.bp
@@ -137,6 +137,7 @@ UnitBlueprint{
         SelectionCenterOffsetZ = 9.1,
         SelectionSizeX = 2.8,
         SelectionSizeZ = 3.2,
+        UISelection = Sound { Bank = 'SeraphimSelect', Cue = 'Seraphim_Select_Factory', LodCutoff = 'UnitMove_LodCutoff' },
     },
     Footprint = {
         SizeX = 5,


### PR DESCRIPTION
## Description of the proposed changes
Add a selection sound for external factories to make their UI responsiveness consistent with other factories in the game.

## Testing done on the proposed changes
Factory selection sound is played when you select the external factory with the UI button.
No errors in log.
Checked that all units with EXTERNALFACTORY category are updated.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External factories now play their faction-appropriate factory selection sound when selected.
  * Added factory selection audio for supported Aeon, UEF, Cybran, and Seraphim units.

* **Bug Fixes**
  * External factory units now correctly inherit or use their configured selection sound.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->