### PR TITLE
Fix economy bar resource group warning backgrounds not lighting up

### DIFF
--- a/changelog/snippets/category.7209.md
+++ b/changelog/snippets/category.7209.md
@@ -1,0 +1,1 @@
+- Your explanation here... [Don't forget to change the category in the filename] (#7209).

--- a/lua/ui/game/economy.lua
+++ b/lua/ui/game/economy.lua
@@ -332,11 +332,15 @@ function ConfigureBeatFunction()
         local warnOnResourceFull = resourceType == "MASS" and econ_warnings
         local getRateColour = getGetRateColour(warnOnResourceFull, econ_warnings)
 
+        ---@type fun(effVal: number, storedVal: number, maxStorageVal: number)
         local ShowUIWarnings
         if not econ_warnings then
             ShowUIWarnings = function() end
         else
             if warnOnResourceFull then
+                ---@param effVal number Resource produced divided by requested, in percent (multiplied by 100).
+                ---@param storedVal number
+                ---@param maxStorageVal number
                 ShowUIWarnings = function(effVal, storedVal, maxStorageVal)
                     if storedVal / maxStorageVal > 0.8 then
                         if effVal > 200 then
@@ -351,6 +355,9 @@ function ConfigureBeatFunction()
                     end
                 end
             else
+                ---@param effVal number Resource produced divided by requested, in percent (multiplied by 100).
+                ---@param storedVal number
+                ---@param maxStorageVal number
                 ShowUIWarnings = function(effVal, storedVal, maxStorageVal)
                     if storedVal / maxStorageVal < 0.2 then
                         if effVal < 25 then

--- a/lua/ui/game/economy.lua
+++ b/lua/ui/game/economy.lua
@@ -339,11 +339,11 @@ function ConfigureBeatFunction()
             if warnOnResourceFull then
                 ShowUIWarnings = function(effVal, storedVal, maxStorageVal)
                     if storedVal / maxStorageVal > 0.8 then
-                        if effVal > 2.0 then
+                        if effVal > 200 then
                             warningBG:SetToState('red')
-                        elseif effVal > 1.0 then
+                        elseif effVal > 100 then
                             warningBG:SetToState('yellow')
-                        elseif effVal < 1.0 then
+                        elseif effVal < 100 then
                             warningBG:SetToState('hide')
                         end
                     else
@@ -353,11 +353,11 @@ function ConfigureBeatFunction()
             else
                 ShowUIWarnings = function(effVal, storedVal, maxStorageVal)
                     if storedVal / maxStorageVal < 0.2 then
-                        if effVal < 0.25 then
+                        if effVal < 25 then
                             warningBG:SetToState('red')
-                        elseif effVal < 0.75 then
+                        elseif effVal < 75 then
                             warningBG:SetToState('yellow')
-                        elseif effVal > 1.0 then
+                        elseif effVal > 100 then
                             warningBG:SetToState('hide')
                         end
                     else

--- a/lua/ui/game/economy.lua
+++ b/lua/ui/game/economy.lua
@@ -55,9 +55,9 @@ end
 
 function SetLayout(layout)
     import(UIUtil.GetLayoutFilename('economy')).SetLayout()
-    GameMain.RemoveBeatFunction(_BeatFunction)
+    GameMain.RemoveBeatFunction(_BeatFunction, 'economy.BeatFunction')
     ConfigureBeatFunction()
-    GameMain.AddBeatFunction(_BeatFunction, true)
+    GameMain.AddBeatFunction(_BeatFunction, true, 'economy.BeatFunction')
 
     return CommonLogic()
 end
@@ -481,4 +481,17 @@ end
 
 function InitialAnimation()
     import(UIUtil.GetLayoutFilename('economy')).InitAnimation()
+end
+
+__moduleinfo.OnDirty = function ()
+    ForkThread(import, __moduleinfo.name) 
+end
+
+__moduleinfo.OnReload = function (newModule)
+    for k, v in GUI do
+        if k == 'savedParent' then continue end
+        v:Destroy()
+    end
+    GameMain.RemoveBeatFunction(_BeatFunction, 'economy.BeatFunction')
+    newModule.CreateEconomyBar(savedParent)
 end


### PR DESCRIPTION
## Description of the proposed changes
Corrects interpretation of the effval variable, fixing the mass bar background only showing as red when heavily overflowing instead of transitioning from yellow, and fixing the energy bar background never changing color.

## Testing done on the proposed changes
Spawn some Seraphim engineers and mass extractors, then start building a Yolona. This will overflow mass and stall energy, allowing you to see the warning backgrounds for both resources.

## Checklist
- [x] Changes are annotated, including comments where useful
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
