### PR TITLE
Fix error when worldview with render shapes is destroyed

### DIFF
--- a/changelog/snippets/category.7210.md
+++ b/changelog/snippets/category.7210.md
@@ -1,0 +1,1 @@
+- Your explanation here... [Don't forget to change the category in the filename] (#7210).

--- a/changelog/snippets/category.7210.md
+++ b/changelog/snippets/category.7210.md
@@ -1,1 +1,0 @@
-- Your explanation here... [Don't forget to change the category in the filename] (#7210).

--- a/changelog/snippets/fix.7210.md
+++ b/changelog/snippets/fix.7210.md
@@ -1,0 +1,1 @@
+- Fix error when worldview with render shapes is destroyed (#7210).

--- a/lua/ui/controls/components/WorldViewShapeComponent.lua
+++ b/lua/ui/controls/components/WorldViewShapeComponent.lua
@@ -57,7 +57,7 @@ WorldViewShapeComponent = ClassSimple {
     RemoveShape = function(self, id)
         self.Shapes[id] = nil
 
-        if table.empty(self.Shapes) then
+        if table.empty(self.Shapes) and not IsDestroyed(self) then
             self:SetCustomRender(false)
         end
     end,


### PR DESCRIPTION
## Issue
When a worldview is destroyed, the shapes it cleans up end up calling an engine method, causing an error.
https://github.com/FAForever/fa/blob/a1ec9de7ee544b63aa45d0098469774b7070b762/lua/ui/controls/worldview.lua#L997

https://github.com/FAForever/fa/blob/15346a0c92ff1e07dfe0a38f5d07ac5ad808c527/lua/ui/game/shapes/Shape.lua#L40-L44

https://github.com/FAForever/fa/blob/8c180cbac53c72792a2f38201a2dc2f105b4e6a5/lua/ui/controls/components/WorldViewShapeComponent.lua#L57-L63

## Description of the proposed changes
Check the worldview is not destroyed before calling.

## Testing done on the proposed changes
The error no longer occurs with my ui mods.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
