### PR TITLE
Do not play ambient move sounds when changing layers

### DIFF
--- a/changelog/snippets/category.7211.md
+++ b/changelog/snippets/category.7211.md
@@ -1,0 +1,1 @@
+- Your explanation here... [Don't forget to change the category in the filename] (#7211).

--- a/lua/sim/Unit.lua
+++ b/lua/sim/Unit.lua
@@ -3432,12 +3432,8 @@ Unit = ClassUnit(moho.unit_methods, IntelComponent, VeterancyComponent, DebugUni
 
         if new == 'Land' then
             self:PlayUnitSound('TransitionLand')
-            self:PlayUnitAmbientSound('AmbientMoveLand')
         elseif new == 'Water' or new == 'Seabed' then
             self:PlayUnitSound('TransitionWater')
-            self:PlayUnitAmbientSound('AmbientMoveWater')
-        elseif new == 'Sub' then
-            self:PlayUnitAmbientSound('AmbientMoveSub')
         end
 
         local movementEffects = self.Blueprint.Display.MovementEffects


### PR DESCRIPTION
## Description of the proposed changes
The ambient move sound is handled by `OnMotionHorzEventChange`
Playing on layer change causes the ambient sound to be played when the unit is spawned, which is very loud in the case of the Fatboy.

## Testing done on the proposed changes
Spawn a fatboy and do not move it. It should not play the loud engine noise.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
