### PR TITLE
Fix commandmode radar adjacency check

### DIFF
--- a/changelog/snippets/category.7212.md
+++ b/changelog/snippets/category.7212.md
@@ -1,0 +1,1 @@
+- Your explanation here... [Don't forget to change the category in the filename] (#7212).

--- a/changelog/snippets/category.7212.md
+++ b/changelog/snippets/category.7212.md
@@ -1,1 +1,0 @@
-- Your explanation here... [Don't forget to change the category in the filename] (#7212).

--- a/changelog/snippets/fix.7212.md
+++ b/changelog/snippets/fix.7212.md
@@ -1,0 +1,1 @@
+- Fix assisting to upgrade T2 radars not checking for any adjacent pgens to be built first (#7212).

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -414,7 +414,7 @@ local function OnGuardUpgrade(guardees, unit)
 
     if upgradeRadarTech2 and
         EntityCategoryContains(categories.STRUCTURE * categories.RADAR * categories.TECH2, unit) and
-        unitBlueprint.Economy.ConsumptionPerSecondEnergy > unit:GetEconData().energyConsumed -- check for any adjacency
+        unitBlueprint.Economy.MaintenanceConsumptionPerSecondEnergy > unit:GetEconData().energyConsumed -- check for any adjacency
     then
         ForkThread(UpgradeUnit, unit)
         return


### PR DESCRIPTION
## Description of the proposed changes
Fix commandmode "assist to upgrade" option's radar adjacency check. A typo for the blueprint value was causing it. `ConsumptionPerSecondEnergy ` exists in the bp but is never assigned nor used.

## Testing done on the proposed changes
<!-- List all relevant testing that you've done to confirm the changes work. -->


## Additional context
<!-- Add any other context about the pull request here. -->


## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
