### PR TITLE
Handle UTF chars in chat edit box

### DIFF
--- a/changelog/snippets/features.7098.md
+++ b/changelog/snippets/features.7098.md
@@ -1,4 +1,4 @@
-- Rework the chat window (#7098, #7148, #7157).
+- Rework the chat window (#7098, #7148, #7157, #7214).
 
   The chat window is re-implemented from scratch. It is rebuilt using the MVC-principle, creating a clear separation between state, viewing the state and interacting with the state. This rework fixes a few bugs:
 

--- a/lua/ui/game/chat/ChatEditInterface.lua
+++ b/lua/ui/game/chat/ChatEditInterface.lua
@@ -15,6 +15,7 @@ local ChatCompletion = import("/lua/ui/game/chat/ChatCompletion.lua")
 local ChatUtils = import("/lua/ui/game/chat/ChatUtils.lua")
 local ChatListInterface = import("/lua/ui/game/chat/ChatListInterface.lua").ChatListInterface
 local ChatCommandHintInterface = import("/lua/ui/game/chat/ChatCommandHintInterface.lua").ChatCommandHintInterface
+local AddUnicodeCharToEditText = import("/lua/utf.lua").AddUnicodeCharToEditText
 
 local LazyVarDerive = import("/lua/lazyvar.lua").Derive
 
@@ -162,6 +163,9 @@ ChatEditInterface = ClassUI(Group) {
         ---@param keycode number     # OS-level VK_* code
         ---@param event KeyEvent
         self.EditBox.OnNonTextKeyPressed = function(_, keycode, event)
+            -- Accept Unicode characters that arrive via the non-text key path
+            -- before handling navigation shortcuts.
+            if AddUnicodeCharToEditText(self.EditBox, keycode) then return end
             ChatController.NotifyActivity()
             local chatInterface = import("/lua/ui/game/chat/ChatInterface.lua")
             local mods = event and event.Modifiers


### PR DESCRIPTION
## Description of the proposed changes
Standard text input behavior as seen in lobby.lua and the base class.
https://github.com/FAForever/fa/blob/aa746bec58a3be838dba3349193a8de57b318359/lua/maui/edit.lua#L153-L155
https://github.com/FAForever/fa/blob/56ea5f9dd1e5945dcc9633317284724336506360/lua/ui/lobby/lobby.lua#L4619-L4622

## Testing done on the proposed changes

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for entering Unicode characters in chat input fields.
* **Bug Fixes**
  * Improved chat-window behavior, including UI scaling and frame snapping.
  * Added support for chat commands, extensible commands, name autocomplete, simulation messages, clipboard copying, and bottom-up message ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->