### PR TITLE
Add `*_save.lua` to ignored directories for LuaLS

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,12 @@
   "Lua.workspace.checkThirdParty": false,
   "Lua.runtime.path": ["/?"],
   "Lua.runtime.plugin": ".vscode/fa-plugin.lua",
-  "Lua.workspace.ignoreDir": [".vscode", "loc", "*.bp", "lua/ui/lobby/changelog/generated/*"],
+  "Lua.workspace.ignoreDir": [
+    ".vscode/",
+    "loc/",
+    "*.bp",
+    "lua/ui/lobby/changelog/generated/"
+  ],
   "[lua]": {
     "editor.wordBasedSuggestions": "off"
   },
@@ -41,10 +46,10 @@
     "__blueprints"
   ],
   "Lua.format.defaultConfig": {
-    "max_line_length": "unset",
+    "max_line_length": "unset"
   },
   "[markdown]": {
-    "editor.tabSize": 2,
+    "editor.tabSize": 2
   },
 
   // used for grammar checks of changelog

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,7 +15,8 @@
     ".vscode/",
     "loc/",
     "*.bp",
-    "lua/ui/lobby/changelog/generated/"
+    "lua/ui/lobby/changelog/generated/",
+    "*_save.lua"
   ],
   "[lua]": {
     "editor.wordBasedSuggestions": "off"

--- a/changelog/snippets/category.7216.md
+++ b/changelog/snippets/category.7216.md
@@ -1,1 +1,0 @@
-- Your explanation here... [Don't forget to change the category in the filename] (#7216).

--- a/changelog/snippets/category.7216.md
+++ b/changelog/snippets/category.7216.md
@@ -1,0 +1,1 @@
+- Your explanation here... [Don't forget to change the category in the filename] (#7216).


### PR DESCRIPTION
## Description of the proposed changes
These are large generated files that do not need to be parsed.

## Testing done on the proposed changes
Workspace diagnostic shows less loaded files.
No warning about perftest save file being too large.

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
~~- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).~~
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
