### PR TITLE
Rebalance Engineering Stations

### DIFF
--- a/changelog/snippets/balance.7220.md
+++ b/changelog/snippets/balance.7220.md
@@ -1,0 +1,10 @@
+{% unit XRB0304 %}
+T2 and T3 Engineering Stations
+{% endunit %}
+Following their previous nerf, Hives were very rarely built, largely because they became less than half as mass-efficient as T3 engineers. Since Hives were too dominant at 75 build power and virtually non-existent at 50, moving them to 60 build power provides a solid middle ground. The Kennel receives a similar buff, as it suffered from similar problems. (#7220)
+- The Hive (Level 2):
+  - Build Power: 37 -> 40
+- The Hive (Level 3):
+  - Build Power: 50 -> 60
+- C-D2 "Rover-2":
+  - Build Power: 25 -> 30

--- a/units/XEA3204/XEA3204_unit.bp
+++ b/units/XEA3204/XEA3204_unit.bp
@@ -77,7 +77,7 @@ UnitBlueprint{
     Economy = {
         BuildCostEnergy = 1000,
         BuildCostMass = 100,
-        BuildRate = 25,
+        BuildRate = 30,
         BuildTime = 500,
     },
     General = {

--- a/units/XRB0204/XRB0204_unit.bp
+++ b/units/XRB0204/XRB0204_unit.bp
@@ -88,7 +88,7 @@ UnitBlueprint{
     Economy = {
         BuildCostEnergy = 4200,
         BuildCostMass = 700,
-        BuildRate = 37,
+        BuildRate = 40,
         BuildTime = 1000,
         BuildableCategory = { "xrb0304" },
         UpgradeOnlyCategory = { "xrb0304" },

--- a/units/XRB0304/XRB0304_unit.bp
+++ b/units/XRB0304/XRB0304_unit.bp
@@ -84,7 +84,7 @@ UnitBlueprint{
     Economy = {
         BuildCostEnergy = 6300,
         BuildCostMass = 1050,
-        BuildRate = 50,
+        BuildRate = 60,
         BuildTime = 1120,
         DifferentialUpgradeCostCalculation = true,
         MaxBuildDistance = 25,


### PR DESCRIPTION
## Description of the proposed changes
Following their nerf, Hives are, for all practical purposes, almost never built.  Given that they are currently less than half as mass-efficient as T3 engineers, this comes as no surprise. Since Hives were too powerful at 75 build power and virtually non-existent at 50, 60 build power seems like a solid middle ground. The Kennel receives a similar buff, being equally inefficient and rarely used.

Since spamming engineering stations is taxing on sim speed, these units receive build power buffs instead of cost adjustments.

## Stat Comparison
| Metric | T3 Engineer | T3 Hive (50 BP) | T3 Hive (60 BP) | T3 Hive (75 BP) |
| :--- | :---: | :---: | :---: | :---: |
| **Mass Cost** | 312 | 1,050 | 1,050 | 1,050 |
| **Build Power (BP)** | 32.5 | 50 | 60 | 75 |
| **BP / Mass** *(higher is better)* | **0.104** | **0.048** | **0.057** | **0.071** |
| **Mass / BP** *(lower is better)* | **9.6** | **21.0** | **17.5** | **14.0** |

## Checklist
- [ ] ~Changes are annotated, including comments where useful~
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Balance Changes**
  * Increased the XEA3204 engineering drone’s build rate from 25 to 30.
  * Increased the XRB0204 engineering station’s build rate from 37 to 40.
  * Increased the XRB0304 engineering station’s build rate from 50 to 60.
  * Engineering units now construct structures and units more quickly, improving the speed of base expansion, repairs, and battlefield reinforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->