### PR TITLE
Fix error with shields that have a mix of guards with and without queues

### DIFF
--- a/changelog/snippets/category.7227.md
+++ b/changelog/snippets/category.7227.md
@@ -1,0 +1,1 @@
+- Your explanation here... [Don't forget to change the category in the filename] (#7227).

--- a/changelog/snippets/category.7227.md
+++ b/changelog/snippets/category.7227.md
@@ -1,1 +1,0 @@
-- Your explanation here... [Don't forget to change the category in the filename] (#7227).

--- a/changelog/snippets/fix.7227.md
+++ b/changelog/snippets/fix.7227.md
@@ -1,0 +1,1 @@
+- Fix error with shields that have a mix of guards with and without orders queued after the assist order (#7227).

--- a/lua/shield.lua
+++ b/lua/shield.lua
@@ -593,15 +593,22 @@ Shield = ClassShield(moho.shield_methods, Entity) {
             if tick > owner.tickIssuedShieldRepair and not owner:IsUnitState("Upgrading") then
                 owner.tickIssuedShieldRepair = tick
                 local guards = UnitGetGuards(owner)
-                if not TableEmpty(guards) then
+                local numGuards = TableGetn(guards)
+                if numGuards > 0 then
                     -- filter out guards with something queued after the shield assist order, as to not delete clear their queue
-                    for i, guard in guards do
+                    local i = 1
+                    while i <= numGuards do
+                        local guard = guards[i]
                         if TableGetn(UnitGetCommandQueue(guard)) >= 2 then
-                            guards[i] = nil
+                            guards[i] = guards[numGuards]
+                            guards[numGuards] = nil
+                            numGuards = numGuards - 1
+                        else
+                            i = i + 1
                         end
                     end
 
-                    if not TableEmpty(guards) then
+                    if numGuards > 0 then
                         -- For the filtered guards, clear their assist order, order repair, then re-add the assist order after
                         IssueClearCommands(guards)
                         IssueRepair(guards, owner)


### PR DESCRIPTION
## Description of the proposed changes
The old removal was sometimes not creating a continuous array afterwards, which made the engine function call error.
Use a new removal method to keep the table a continuous array.

## Testing done on the proposed changes
Groundfire with the sacus to damage the shield. Have some acus assist and others assist + move afterwards. No errors appear in log when shield is damaged.
```
   CreateUnitAtMouse('xab1401', 0,    4.12,  -12.92, -0.00000)
   CreateUnitAtMouse('ual0301_nanocombat', 0,   -6.89,   -2.99, -0.31830)
   CreateUnitAtMouse('uab4301', 0,    4.12,   -3.92, -0.00000)
   CreateUnitAtMouse('ual0301_nanocombat', 0,   -6.59,   -0.43,  0.16123)
   CreateUnitAtMouse('ual0301_nanocombat', 0,   -3.99,   -0.20,  0.10709)
   CreateUnitAtMouse('ual0301_nanocombat', 0,   -7.76,    2.99, -0.02355)
   CreateUnitAtMouse('ual0301_nanocombat', 0,   -0.52,   -0.66, -0.00000)
   CreateUnitAtMouse('ual0301_nanocombat', 0,   -1.44,    1.18, -0.00000)
   CreateUnitAtMouse('ual0301_nanocombat', 0,    0.76,    1.79, -0.00000)
   CreateUnitAtMouse('ual0301_nanocombat', 0,   -0.58,    3.10, -0.00000)
   CreateUnitAtMouse('ual0301_nanocombat', 0,    8.18,    5.15,  1.86110)
   CreateUnitAtMouse('ual0301_nanocombat', 0,   10.57,    6.89,  1.64768)
```

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
