### PR TITLE
Fix error with interrupt pathfinding when engi is immobile

### DIFF
--- a/changelog/snippets/category.7228.md
+++ b/changelog/snippets/category.7228.md
@@ -1,1 +1,0 @@
-- Your explanation here... [Don't forget to change the category in the filename] (#7228).

--- a/changelog/snippets/category.7228.md
+++ b/changelog/snippets/category.7228.md
@@ -1,0 +1,1 @@
+- Your explanation here... [Don't forget to change the category in the filename] (#7228).

--- a/changelog/snippets/fix.7228.md
+++ b/changelog/snippets/fix.7228.md
@@ -1,0 +1,1 @@
+- Fix error when using interrupt pathfinding on immobile engineers (#7228).

--- a/engine/Sim/Unit.lua
+++ b/engine/Sim/Unit.lua
@@ -221,8 +221,10 @@ end
 function Unit:GetHealth()
 end
 
---- Returns the navigator object of this unit
----@return Navigator
+--- Returns the navigator object of this unit. 
+--- 
+--- Returns `nil` for immobile units.
+---@return Navigator?
 function Unit:GetNavigator()
 end
 

--- a/lua/sim/commands/abort-navigation.lua
+++ b/lua/sim/commands/abort-navigation.lua
@@ -42,7 +42,9 @@ function AbortNavigation(units, doPrint)
         local unit = units[k]
         if not IsDestroyed(unit) then
             local navigator = unit:GetNavigator()
-            navigator:AbortMove()
+            if navigator then
+                navigator:AbortMove()
+            end
             unit:RefocusAssisters()
         end
     end


### PR DESCRIPTION
## Description of the proposed changes
Check for navigator before trying to interrupt it.

You could filter out immobile units in the category expression calling the function as an alternative fix, but the function has a dual purpose of refocusing assisters so that's not possible.

## Testing done on the proposed changes

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
