### PR TITLE
Fix MaxHealth buff leaving current health above max health

### DIFF
--- a/changelog/snippets/category.7230.md
+++ b/changelog/snippets/category.7230.md
@@ -1,0 +1,1 @@
+- Your explanation here... [Don't forget to change the category in the filename] (#7230).

--- a/changelog/snippets/category.7230.md
+++ b/changelog/snippets/category.7230.md
@@ -1,1 +1,0 @@
-- Your explanation here... [Don't forget to change the category in the filename] (#7230).

--- a/changelog/snippets/fix.7230.md
+++ b/changelog/snippets/fix.7230.md
@@ -1,0 +1,4 @@
+- Fix `MaxHealth` buffs (used by regen aura) not setting health to a lower new max health value (#7230).
+  - Fixes aircraft getting stuck in air staging after losing the regen aura buff.
+  - Fixes units taking less damage than expected for 1 shot after losing the regen aura buff.
+  - Fixes units instantly refilling to the boosted max HP when regaining the regen aura buff.

--- a/lua/sim/Buff.lua
+++ b/lua/sim/Buff.lua
@@ -304,12 +304,21 @@ BuffEffects = {
         val = math.round(val)
 
         local oldmax = unit:GetMaxHealth()
-        local difference = oldmax - unit:GetHealth()
+        local health = unit:GetHealth()
+        local difference = oldmax - health
 
         unit:SetMaxHealth(val)
 
-        if not buffValues.DoNotFill and not unit.IsBeingTransferred then
-            unit:SetHealth(unit, unit:GetMaxHealth() - difference)
+        if not unit.IsBeingTransferred then
+            if not buffValues.DoNotFill then
+                unit:SetHealth(unit, unit:GetMaxHealth() - difference)
+            elseif val < health then
+                -- Set health because it stays above max health until the next AdjustHealth call
+                -- this causes AdjustHealth to be fully absorbed 
+                -- this causes air units to get stuck repairing in air staging
+                -- it also makes DoNotFill buffs seemingly fill HP if the buff was removed and re-applied
+                unit:SetHealth(unit, val)
+            end
         end
     end,
 


### PR DESCRIPTION
## Issue
Originates from an investigation related to #7184 in #7219:
> I investigated this further and this seems like a more core bug to the MaxHealth Buff used by regen aura. When the buff is removed, it sets the max health below the current health, but the engine keeps that current health value until the next call of AdjustHealth. This causes numerous bugs:
> - The health greater than max is used to calculate the health adjustment, and the max health ceiling kicks in after. For example, a unit that gained and then lost 500 max HP will only take 100 damage if hit by a 600 damage projectile.
> - Air units get stuck in air staging due to the engine checking health == maxhealth to undock units.
> - If the unit does not take damage and regains the max health buff, its HP is restored to the large value even though the buff blueprint specifies that it should not fill the target's health upon application.
> 
> For these reasons I'd rather fix the health buff and I don't see a reason for this air staging code to exist.

## Description of the changes
When the MaxHealth buff's value causes a max health reduction below the current health, reduce the current health to the new max health.

## Testing done on the proposed changes
Have a unit enter and then leave a regen aura field.
The following command should not show the unit's HP bein above its max HP.
```
ConExecute([[SimLua LOG(SelectedUnit():GetHealth()) ]])
```

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
