### PR TITLE
Add dark mode to github pages

### DIFF
--- a/changelog/snippets/category.7239.md
+++ b/changelog/snippets/category.7239.md
@@ -1,0 +1,1 @@
+- Your explanation here... [Don't forget to change the category in the filename] (#7239).

--- a/changelog/snippets/category.7239.md
+++ b/changelog/snippets/category.7239.md
@@ -1,1 +1,0 @@
-- Your explanation here... [Don't forget to change the category in the filename] (#7239).

--- a/changelog/snippets/other.7239.md
+++ b/changelog/snippets/other.7239.md
@@ -1,0 +1,1 @@
+- Add optional dark mode to the changelog website (#7239).

--- a/docs/_includes/head_custom.html
+++ b/docs/_includes/head_custom.html
@@ -1,0 +1,12 @@
+<link rel="stylesheet" href="{{ '/assets/css/just-the-docs-faf-dark.css' | relative_url }}" id="dark-scheme-stylesheet" disabled>
+<script>
+  (function () {
+    var stored = localStorage.getItem('faf-color-scheme');
+    var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    var dark = stored ? stored === 'dark' : prefersDark;
+    if (dark) {
+      document.getElementById('dark-scheme-stylesheet').removeAttribute('disabled');
+      document.documentElement.setAttribute('data-color-scheme', 'dark');
+    }
+  })();
+</script>

--- a/docs/_includes/header_custom.html
+++ b/docs/_includes/header_custom.html
@@ -12,7 +12,10 @@
       darkLink.disabled = !dark;
       document.documentElement.setAttribute('data-color-scheme', dark ? 'dark' : 'light');
       localStorage.setItem('faf-color-scheme', dark ? 'dark' : 'light');
+      btn.textContent = dark ? '☀️' : '🌙';
     }
+
+    btn.textContent = isDark() ? '☀️' : '🌙';
 
     btn.addEventListener('click', function () {
       apply(!isDark());

--- a/docs/_includes/header_custom.html
+++ b/docs/_includes/header_custom.html
@@ -1,0 +1,21 @@
+<button id="color-scheme-toggle" class="btn" type="button" aria-label="Toggle dark mode" title="Toggle dark mode">🌙</button>
+<script>
+  (function () {
+    var btn = document.getElementById('color-scheme-toggle');
+    var darkLink = document.getElementById('dark-scheme-stylesheet');
+
+    function isDark() {
+      return !darkLink.disabled;
+    }
+
+    function apply(dark) {
+      darkLink.disabled = !dark;
+      document.documentElement.setAttribute('data-color-scheme', dark ? 'dark' : 'light');
+      localStorage.setItem('faf-color-scheme', dark ? 'dark' : 'light');
+    }
+
+    btn.addEventListener('click', function () {
+      apply(!isDark());
+    });
+  })();
+</script>

--- a/docs/_sass/color_schemes/faf-dark.scss
+++ b/docs/_sass/color_schemes/faf-dark.scss
@@ -1,0 +1,5 @@
+@import "./color_schemes/dark";
+
+h1 {
+  font-weight: 600;
+}

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -21,21 +21,20 @@
 }
 
 .change {
-  font-weight: 300;
 }
 
 .old {
-  color: #d73a49;
+  color: #cf222e;
   text-decoration: line-through;
 }
 
 .new {
-  color: #2da44e;
+  color: #1a7f37;
 }
 
 [data-color-scheme="dark"] {
   .old {
-    color: #ff7b72;
+    color: #f85149;
   }
 
   .new {

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -32,3 +32,13 @@
 .new {
   color: #2da44e;
 }
+
+[data-color-scheme="dark"] {
+  .old {
+    color: #ff7b72;
+  }
+
+  .new {
+    color: #3fb950;
+  }
+}

--- a/docs/assets/css/just-the-docs-faf-dark.scss
+++ b/docs/assets/css/just-the-docs-faf-dark.scss
@@ -1,0 +1,3 @@
+---
+---
+{% include css/just-the-docs.scss.liquid color_scheme="faf-dark" %}


### PR DESCRIPTION
## Description of the proposed changes
I had Claude implement a button to switch between light and dark mode on our documentation website.

<img width="889" height="733" alt="grafik" src="https://github.com/user-attachments/assets/d1562f7a-c457-48b2-889a-b50a3c2fbf9c" />

## Testing done on the proposed changes
I tested it in a local environment.


## Checklist
- [ ] Changes are annotated, including comments where useful
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional dark mode to the changelog website.
  * Added a toggle to switch between light and dark themes.
  * Theme preference is saved and can follow the system’s appearance setting.

* **Style**
  * Updated changelog colors and typography for improved readability in both themes.
  * Added dark-mode styling for change indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->