### PR TITLE
Fix FactionIndex build condition

### DIFF
--- a/changelog/snippets/fix.7241.md
+++ b/changelog/snippets/fix.7241.md
@@ -1,0 +1,1 @@
+- Fixed Faction index build condition for campaign platoons, causing some platoons not being built properly

--- a/lua/sim/ScenarioUtilities.lua
+++ b/lua/sim/ScenarioUtilities.lua
@@ -1607,7 +1607,6 @@ function LoadOSB(buildName, strArmy, builderData)
                     for subNum, val in cond[3] do
                         table.insert(params, val)
                     end
-                    table.remove(params, 1)
                     insert = import(cond[1])[ cond[2] ](aiBrain, unpack(params))
                 end
             end


### PR DESCRIPTION
This was removing the "default_brain" by assuming its the first item in the list and seems to be an special case just for the faction index build condition, so it slipped through the cleaning https://github.com/FAForever/fa/commit/c8f426053c2a0a9d63196ccb6699aefa7a25707e

Also much harder to spot, since a lot of the platoons kept working.

## Testing done on the proposed changes
Tested on the affected coop missions.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed faction build-condition handling that prevented some campaign platoons from being built.
  * Imported conditions now receive the complete set of parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->