### PR TITLE
Fix distance check for closest structure to build

### DIFF
--- a/changelog/snippets/fix.7242.md
+++ b/changelog/snippets/fix.7242.md
@@ -1,0 +1,1 @@
+- Fixed distance check for picking the closest structure to build by the campaign AI

--- a/lua/AI/OpAI/BaseManagerPlatoonThreads.lua
+++ b/lua/AI/OpAI/BaseManagerPlatoonThreads.lua
@@ -1077,7 +1077,7 @@ function BuildBaseManagerStructure(aiBrain, eng, baseManager, levelName, buildin
                 for num, location in v do
                     -- Check if it can be built and then build
                     if num > 1 and aiBrain:CanBuildStructureAt(category, {location[1], 0, location[2]}) and baseManager:CheckUnitBuildCounter(location, buildCounter) then
-                        if not closest or VDist2(location[1], location[3], engineerPos[1], engineerPos[3]) < VDist2(closest[1], closest[3], engineerPos[1], engineerPos[3]) then
+                        if not closest or VDist2(location[1], location[2], engineerPos[1], engineerPos[3]) < VDist2(closest[1], closest[2], engineerPos[1], engineerPos[3]) then
                             closest = location
                         end
                     end


### PR DESCRIPTION
## Description of the proposed changes
The structure positions in the base template are stored as X Z 0 instead of X Y Z, so we need to check for the 2 value in the table

## Testing done on the proposed changes
Checked how the campaign AI builds a base from a scratch.


## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
