### PR TITLE
Apply damage modifiers to nuke weapons

### DIFF
--- a/changelog/snippets/category.7245.md
+++ b/changelog/snippets/category.7245.md
@@ -1,0 +1,1 @@
+- Your explanation here... [Don't forget to change the category in the filename] (#XYZW).

--- a/changelog/snippets/category.7245.md
+++ b/changelog/snippets/category.7245.md
@@ -1,1 +1,0 @@
-- Your explanation here... [Don't forget to change the category in the filename] (#XYZW).

--- a/changelog/snippets/fix.7245.md
+++ b/changelog/snippets/fix.7245.md
@@ -1,0 +1,1 @@
+- Fix damage and splash radius modifiers not applying to weapons such as nukes that have splash damage with falloff (#7245).

--- a/lua/sim/weapon.lua
+++ b/lua/sim/weapon.lua
@@ -560,9 +560,17 @@ Weapon = ClassWeapon(WeaponMethods, DebugWeaponComponent) {
             if bp.NukeOuterRingDamage and bp.NukeOuterRingRadius and bp.NukeOuterRingTicks and bp.NukeOuterRingTotalTime and
                 bp.NukeInnerRingDamage and bp.NukeInnerRingRadius and bp.NukeInnerRingTicks and bp.NukeInnerRingTotalTime then
                 proj.InnerRing = NukeDamage()
-                proj.InnerRing:OnCreate(bp.NukeInnerRingDamage, bp.NukeInnerRingRadius, bp.NukeInnerRingTicks, bp.NukeInnerRingTotalTime)
+                proj.InnerRing:OnCreate(bp.NukeInnerRingDamage + self.DamageMod,
+                    bp.NukeInnerRingRadius + self.DamageRadiusMod,
+                    bp.NukeInnerRingTicks,
+                    bp.NukeInnerRingTotalTime
+                )
                 proj.OuterRing = NukeDamage()
-                proj.OuterRing:OnCreate(bp.NukeOuterRingDamage, bp.NukeOuterRingRadius, bp.NukeOuterRingTicks, bp.NukeOuterRingTotalTime)
+                proj.OuterRing:OnCreate(bp.NukeOuterRingDamage + self.DamageMod,
+                    bp.NukeOuterRingRadius + self.DamageRadiusMod,
+                    bp.NukeOuterRingTicks,
+                    bp.NukeOuterRingTotalTime
+                )
 
                 -- Need to store these three for later, in case the missile lands after the launcher dies
                 proj.Launcher = self.unit


### PR DESCRIPTION
## Issue
The "roguelike mode" mod changes `weapon.DamageMod` and `DamageRadiusMod` to apply its buffs. I did not expect that these buffs do not apply to nuke weapons like the UEF ACU's billy nuke.

## Description of the proposed changes
Add the modifier values in NukeDamage initialization for the damage and radius parameters.

## Testing done on the proposed changes

## Checklist
~~- [ ] Changes are annotated, including comments where useful~~
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed damage modifiers not applying to weapons with splash-damage falloff, including nukes.
  - Fixed splash-radius modifiers so affected weapons now use their adjusted inner and outer blast radii correctly.
- **Documentation**
  - Added a changelog entry describing the modifier fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->