### PR TITLE
Cleanup utils and add annotations

### DIFF
--- a/changelog/snippets/other.7247.md
+++ b/changelog/snippets/other.7247.md
@@ -1,3 +1,5 @@
-- Added missing annotations to string functions
-- `StringJoin` now points to `table.concat`. Since thats exactly what it did.
-- `StringStartsWith` points directly to `StringStarts` since one of them is duplicate due oversight of existing function by someone in the past.
+- Added missing annotations to string functions (#7247).
+  
+- `StringJoin` now points to `table.concat`. Since that's exactly what it did (#7247).
+
+- `StringStartsWith` points directly to `StringStarts` since one of them is duplicate due oversight of existing function by someone in the past (#7247).

--- a/changelog/snippets/other.7247.md
+++ b/changelog/snippets/other.7247.md
@@ -1,0 +1,3 @@
+- Added missing annotations to string functions
+- `StringJoin` now points to `table.concat`. Since thats exactly what it did.
+- `StringStartsWith` points directly to `StringStarts` since one of them is duplicate due oversight of existing function by someone in the past.

--- a/changelog/snippets/other.7247.md
+++ b/changelog/snippets/other.7247.md
@@ -1,5 +1,5 @@
-- Added missing annotations to string functions (#7247).
+- Add missing annotations to string functions (#7247).
   
-- `StringJoin` now points to `table.concat`, which provides the same behavior (#7247).
+- Point `StringJoin` at `table.concat`, which provides the same behavior (#7247).
 
-- `StringStartsWith` now points to `StringStarts`; the two functions were previously duplicated due to an oversight (#7247).
+- Point `StringStartsWith` at `StringStarts`; the two functions were previously duplicated due to an oversight (#7247).

--- a/changelog/snippets/other.7247.md
+++ b/changelog/snippets/other.7247.md
@@ -1,5 +1,5 @@
 - Added missing annotations to string functions (#7247).
   
-- `StringJoin` now points to `table.concat`. Since that's exactly what it did (#7247).
+- `StringJoin` now points to `table.concat`, which provides the same behavior (#7247).
 
-- `StringStartsWith` points directly to `StringStarts` since one of them is duplicate due oversight of existing function by someone in the past (#7247).
+- `StringStartsWith` now points to `StringStarts`; the two functions were previously duplicated due to an oversight (#7247).

--- a/lua/keymap/smartSelection.lua
+++ b/lua/keymap/smartSelection.lua
@@ -49,7 +49,7 @@ function compile(strExpression)
   local tokens = utils.StringSplit(strExpression, " ") -- split by space
   for k,v in tokens do
 
-    if utils.StringStartsWith(v, "-") then
+    if utils.StringStarts(v, "-") then
       -- tokens with minus symbol are "negative"
       local withoutSymbol = string.sub(v,2)
       table.insert(result.negatives, withoutSymbol)

--- a/lua/sim/ScenarioUtilities.lua
+++ b/lua/sim/ScenarioUtilities.lua
@@ -704,7 +704,7 @@ function InitializeScenarioArmies()
     local import = import
     local GetArmyBrain = GetArmyBrain
     local SetArmyEconomy = SetArmyEconomy
-    local StringStartsWith = StringStartsWith
+    local StringStarts = StringStarts
     local SetArmyFactionIndex = SetArmyFactionIndex
     local SetArmyColorIndex = SetArmyColorIndex
     local SetArmyAIPersonality = SetArmyAIPersonality
@@ -746,7 +746,7 @@ function InitializeScenarioArmies()
 
             local faction = tblData.faction
             if faction ~= nil then
-                if setup.Human or StringStartsWith(strArmy, "Player") then
+                if setup.Human or StringStarts(strArmy, "Player") then
                     local factionIndex = MathClamp(setup.Faction, 1, factionCount)
                     SetArmyFactionIndex(strArmy, factionIndex - 1)
                 else

--- a/lua/system/utils.lua
+++ b/lua/system/utils.lua
@@ -656,7 +656,8 @@ function StringSplit(str, sep)
     sep = sep or ":"
     local fields = {}
     local pattern = string.format("([^%s]+)", sep)
-    local _ = str:gsub(pattern, function(c) fields[table.getn(fields)+1] = c end)
+    ---@diagnostic disable-next-line: discard-returns
+    str:gsub(pattern, function(c) fields[table.getn(fields)+1] = c end)
     return fields
 end
 
@@ -717,7 +718,8 @@ end
 ---@return string
 function StringReverse(str)
     local tbl =  {}
-    local _ = str:gsub(".", function(c) table.insert(tbl,c) end)
+    ---@diagnostic disable-next-line: discard-returns
+    str:gsub(".", function(c) table.insert(tbl,c) end)
     tbl = table.reverse(tbl)
     return table.concat(tbl)
 end

--- a/lua/system/utils.lua
+++ b/lua/system/utils.lua
@@ -694,6 +694,7 @@ end
 
 --- Prepends a string with specified symbol or one space
 ---@param str string
+---@param symbol string? # Defaults to `" "`
 ---@return string
 function StringPrepend(str, symbol)
     if not symbol then symbol = ' ' end

--- a/lua/system/utils.lua
+++ b/lua/system/utils.lua
@@ -677,12 +677,14 @@ end
 
 --- Adds comma as thousands separator in specified value
 --- e.g. StringComma(10000) --> 10,000
+---@param value number
 ---@return string
 function StringComma(value)
-    local str = value or 0
+    local str = value or 0 ---@type number | string
     while true do
       local k
       str, k = string.gsub(str, "^(-?%d+)(%d%d%d)", '%1,%2')
+      ---@cast str string
       if k == 0 then
         break
       end

--- a/lua/system/utils.lua
+++ b/lua/system/utils.lua
@@ -667,7 +667,7 @@ end
 ---@param from string
 ---@param to string
 ---@param fromEnd? boolean Defaults to `false`
----@return unknown
+---@return string?
 function StringExtract(str, from, to, fromEnd)
     local pattern = from .. '(.*)' .. to
     if fromEnd then pattern = '.*' .. pattern end

--- a/lua/system/utils.lua
+++ b/lua/system/utils.lua
@@ -646,35 +646,30 @@ end)
 -- gfind was renamed to gmatch in Lua 5.1. added gmatch for additional compatibility
 rawset(string, 'gmatch', string.gfind)
 
---- Returns items as a single string, separated by the delimiter
-function StringJoin(items, delimiter)
-    local str = "";
-    for k,v in items do
-        str = str .. v .. delimiter
-    end
-    return str
-end
+StringJoin = table.concat
 
 --- "explode" a string into a series of tokens, using a separator character `sep`
 ---@param str string
----@param sep string
+---@param sep? string Defaults to `:`
 ---@return string[]
 function StringSplit(str, sep)
-    local sep, fields = sep or ":", {}
+    sep = sep or ":"
+    local fields = {}
     local pattern = string.format("([^%s]+)", sep)
-    str:gsub(pattern, function(c) fields[table.getn(fields)+1] = c end)
+    local _ = str:gsub(pattern, function(c) fields[table.getn(fields)+1] = c end)
     return fields
 end
 
---- Returns true if the string starts with the specified value
-function StringStartsWith(stringToMatch, valueToSeek)
-    return stringToMatch:sub(1, valueToSeek:len()) == valueToSeek
-end
-
 --- Extracts a string between two specified strings
---- e.g. StringExtract('/path/name_end.lua', '/', '_end', true) --> name
-function StringExtract(str, str1, str2, fromEnd)
-    local pattern = str1 .. '(.*)' .. str2
+---
+--- e.g. `StringExtract('/path/name_end.lua', '/', '_end', true)` --> name
+---@param str string
+---@param from string
+---@param to string
+---@param fromEnd? boolean Defaults to `false`
+---@return unknown
+function StringExtract(str, from, to, fromEnd)
+    local pattern = from .. '(.*)' .. to
     if fromEnd then pattern = '.*' .. pattern end
     local _, _, m = str:find(pattern)
     return m
@@ -682,6 +677,7 @@ end
 
 --- Adds comma as thousands separator in specified value
 --- e.g. StringComma(10000) --> 10,000
+---@return string
 function StringComma(value)
     local str = value or 0
     while true do
@@ -695,6 +691,8 @@ function StringComma(value)
 end
 
 --- Prepends a string with specified symbol or one space
+---@param str string
+---@return string
 function StringPrepend(str, symbol)
     if not symbol then symbol = ' ' end
     return symbol .. str
@@ -702,6 +700,8 @@ end
 
 --- Splits a string with camel case to a string with separate words
 --- e.g. StringSplitCamel('SupportCommanderUnit') -> 'Support Commander Unit'
+---@param str string
+---@return string
 function StringSplitCamel(str)
     local first = str:sub(1, 1)
     local split = first .. str:sub(2):gsub("[A-Z]", StringPrepend)
@@ -710,25 +710,37 @@ end
 
 --- Reverses order of letters for specified string
 --- e.g. StringReverse('abc123') --> 321cba
+---@param str string
+---@return string
 function StringReverse(str)
     local tbl =  {}
-    str:gsub(".", function(c) table.insert(tbl,c) end)
+    local _ = str:gsub(".", function(c) table.insert(tbl,c) end)
     tbl = table.reverse(tbl)
     return table.concat(tbl)
 end
 
 --- Capitalizes each word in specified string
 --- e.g. StringCapitalize('hello supreme commander') --> Hello Supreme Commander
+---@param str string
+---@return string
 function StringCapitalize(str)
     return string.gsub(" "..str, "%W%l", string.upper):sub(2)
 end
 
---- Check if a given string starts with specified string
+---Check if a given string starts with specified string
+---@param str string
+---@param startString string
+---@return boolean
 function StringStarts(str, startString)
-   return StringStartsWith(str, startString)
+   return str:sub(1, startString:len()) == startString
 end
 
---- Check if a given string ends with specified string
+StringStartsWith = StringStarts
+
+---Check if a given string ends with specified string
+---@param str string
+---@param endString string
+---@return boolean
 function StringEnds(str, endString)
    return endString == '' or str:sub(-endString:len()) == endString
 end
@@ -755,7 +767,10 @@ function Sort(itemA, itemB)
     end
 end
 
--- Rounds a number to specified double precision
+---Rounds a number to specified double precision
+---@param num number
+---@param idp? number
+---@return number
 function math.round(num,idp)
     if not idp then
         return math.floor(num+.5)
@@ -766,6 +781,10 @@ function math.round(num,idp)
 end
 
 --- Clamps numeric value to specified Min and Max range
+---@param v number
+---@param min number
+---@param max number
+---@return number
 function math.clamp(v, min, max)
     if v <= min then return min end
     if v >= max then return max end

--- a/tests/utility/string.spec.lua
+++ b/tests/utility/string.spec.lua
@@ -68,10 +68,6 @@ luft.describe("Utils", function()
         end)
     end)
 
-    luft.test("StringStartsWith", function()
-        luft.expect(StringStartsWith("Hello, World", "Hello")).to.equal(true)
-    end)
-
     luft.test("StringExtract", function()
         luft.expect(StringExtract("/path/name_end.lua", '/', "_end", true))
             .to.equal("name")


### PR DESCRIPTION
## Description of the proposed changes
- Added missing annotations to string functions
- `StringJoin` now points to `table.concat`. Since thats exactly what it did.
- `StringStartsWith` points directly to `StringStarts` since one of them is duplicate due oversight of existing function by someone in the past.

## Additional context
The string functions are still bit messy, they should probably all be contained in the global `string` library, same as `table` library is extended in the very same file. But that's probably for another PR.


## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected string joining to consistently match established behavior.
  * Consolidated duplicate string-prefix functionality while preserving existing compatibility.
  * Improved string utility handling and negative-token selection behavior.

* **Documentation**
  * Added type annotations to string and math utilities, improving editor assistance and developer-facing documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->