### PR TITLE
Make land/navy formations move instantly instead of row-by-row

### DIFF
--- a/changelog/snippets/balance.7251.md
+++ b/changelog/snippets/balance.7251.md
@@ -1,6 +1,2 @@
-{% unit <BlueprintID> %}
-<Formatted Unit Name>
-{% endunit %}
-<Description> (#7251)
-- <Category>:
-  - <Parameter Name>: <value before> -> <value after>
+Make land and naval unit formations delay starting movement after every 10th row instead of every row (#7251).
+

--- a/changelog/snippets/balance.7251.md
+++ b/changelog/snippets/balance.7251.md
@@ -1,2 +1,1 @@
 Make land and naval unit formations delay starting movement after every 10th row instead of every row (#7251).
-

--- a/changelog/snippets/balance.7251.md
+++ b/changelog/snippets/balance.7251.md
@@ -1,0 +1,6 @@
+{% unit <BlueprintID> %}
+<Formatted Unit Name>
+{% endunit %}
+<Description> (#7251)
+- <Category>:
+  - <Parameter Name>: <value before> -> <value after>

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -938,7 +938,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable)
                         TableInsert(FormationPos, {
                             xPos * spacing, (-formationLength - offsetY) * spacing,
                             groupData.Filter,
-                            formationLength,
+                            0,
                             true
                         })
                         inserted = true

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -935,7 +935,12 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable)
                             rowType = type
                         end
 
-                        TableInsert(FormationPos, {xPos * spacing, (-formationLength - offsetY) * spacing, groupData.Filter, formationLength, true})
+                        TableInsert(FormationPos, {
+                            xPos * spacing, (-formationLength - offsetY) * spacing,
+                            groupData.Filter,
+                            formationLength,
+                            true
+                        })
                         inserted = true
 
                         groupData.Count = groupData.Count - 1

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -938,7 +938,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable)
                         TableInsert(FormationPos, {
                             xPos * spacing, (-formationLength - offsetY) * spacing,
                             groupData.Filter,
-                            0,
+                            formationLength / 10,
                             true
                         })
                         inserted = true


### PR DESCRIPTION
## Description of the proposed changes
This is a very simple lua change: in formations.lua there is a number `formationLength` added to every `FormationPos[i][4]` in `BlockBuilderLand`. This variable is of type `int` and is essentially a movement delay. We can set it to always be 0 and then units in all formation rows move instantly like in the video.

https://github.com/user-attachments/assets/70c383c6-b48f-4e5b-8bd9-9708583f2922

## Testing done on the proposed changes
Move some large formations around.
These commands, executable from clipboard, helps see the pathfinding:
```lua
ConExecute('dbg navs')
ConExecute('dbg navp')
```

## Checklist
- [x] Changes are annotated, including comments where useful -- See #7259 
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Balance Changes**
  - Land and naval unit formations now pause movement after every 10th row instead of after each row.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->