### PR TITLE
Allow T3 engineers campaign platoon for Aeon and Sera

### DIFF
--- a/changelog/snippets/ai.7253.md
+++ b/changelog/snippets/ai.7253.md
@@ -1,1 +1,1 @@
-- Allows `T3Engineer` OpAI builder for Aeon and Seraphim.
+- Allows `T3Engineer` OpAI builder for Aeon and Seraphim (#7253).

--- a/changelog/snippets/ai.7253.md
+++ b/changelog/snippets/ai.7253.md
@@ -1,0 +1,1 @@
+- Allows `T3Engineer` OpAI builder for Aeon and Seraphim.

--- a/lua/AI/OpAI/EngineerAttack_save.lua
+++ b/lua/AI/OpAI/EngineerAttack_save.lua
@@ -249,8 +249,8 @@ Scenario = {
                             },
                             {
                                 '/lua/editor/miscbuildconditions.lua', 'FactionIndex',
-                                { 1 },
-                                {'1'}
+                                { 1, 2, 4 },
+                                {'1', '2', '4'}
                             },
                         },
                         PlatoonData =


### PR DESCRIPTION
## Description of the proposed changes
Allows this OpAI builder for Aeon and Sera, the builder contains a shield as well so Cybran stays excluded

## Testing done on the proposed changes


## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the T3 Engineer builder so additional factions can now construct T3 engineer platoons.
  * Added support for Aeon and Seraphim faction gameplay.

* **Documentation**
  * Added a changelog entry documenting the expanded faction availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->