### PR TITLE
Fix annotations in cinematics.lua

### DIFF
--- a/changelog/snippets/other.7254.md
+++ b/changelog/snippets/other.7254.md
@@ -1,1 +1,1 @@
-- Fixed annotations in cinematics.lua
+- Fix annotations in cinematics.lua (#7254).

--- a/changelog/snippets/other.7254.md
+++ b/changelog/snippets/other.7254.md
@@ -1,0 +1,1 @@
+- Fixed annotations in cinematics.lua

--- a/lua/SimCamera.lua
+++ b/lua/SimCamera.lua
@@ -28,6 +28,7 @@ function OnCameraFinish(name)
 end
 
 ---@class SimCamera : SingleEvent
+---@overload fun(name: string): SimCamera
 SimCamera = Class(SingleEvent) {
     __init = function(self,name)
         self.CameraName = name

--- a/lua/cinematics.lua
+++ b/lua/cinematics.lua
@@ -35,6 +35,7 @@ function SetInvincible(area, invinBool)
                 table.insert(checkAreas, ScenarioUtils.AreaToRect(v))
             end
         elseif area then
+            ---@cast area -table
             table.insert(checkAreas, ScenarioUtils.AreaToRect(area))
         end
 

--- a/lua/cinematics.lua
+++ b/lua/cinematics.lua
@@ -127,6 +127,7 @@ function CameraTrackEntities(units, zoom, seconds)
     if army ~= -1 then
         for i, v in units do
             if army ~= v.Army then
+                ---@cast units Blip[]
                 units[i] = v:GetBlip(army)
             end
         end

--- a/lua/cinematics.lua
+++ b/lua/cinematics.lua
@@ -24,31 +24,7 @@ function IsOpEnded()
     end
 end
 
---- To be used when starting a cinematic / NIS
-function EnterNISMode()
-    ScenarioInfo.Camera = SimCamera('WorldCamera')
-    LockInput()
-    ScenarioInfo.Camera:UseGameClock()
-    Sync.NISMode = 'on'
-    ScenarioInfo.OpEnded = true
-    -- Take Away UI
-    -- Set Game Speed to normal
-end
-
---- Used at the end of a cinematic / NIS
-function ExitNISMode()
-    -- Set Game Speed to user value
-    -- Restore UI
-    ScenarioInfo.OpEnded = false
-    CameraRevertRotation()
-    Sync.NISMode = 'off'
-    ScenarioInfo.Camera:UseSystemClock()
-    SetInvincible(nil, true)
-    UnlockInput()
-    ScenarioInfo.Camera = nil
-end
-
----@param area Area|Area[]
+---@param area AreaName|AreaName[]|nil
 ---@param invinBool? boolean
 function SetInvincible(area, invinBool)
     if not invinBool then
@@ -77,6 +53,15 @@ function SetInvincible(area, invinBool)
             ScenarioFramework.UnflagUnkillable(v)
         end
     end
+end
+
+--- Used by other functions to make sure that they don't return before the camera is done moving.
+function WaitForCamera()
+    -- Wait for it to be done
+    ScenarioInfo.Camera:WaitFor()
+
+    -- Reset the event tracker, so that the next camera action can be waited for
+    ScenarioInfo.Camera:EventReset()
 end
 
 --- This will move the camera to the position of a marker.
@@ -129,14 +114,6 @@ function CameraMoveToArea(area, seconds)
     CameraMoveToRectangle(rectangle, seconds)
 end
 
---- See track entities
----@param entity Unit
----@param zoom number
----@param seconds? number
-function CameraTrackEntity(entity, zoom, seconds)
-    CameraTrackEntities({entity}, zoom, seconds)
-end
-
 --- This will make the camera track a group of entities.
 --- The "seconds" field is how long it will take to get in place.
 --- After that the camera will follow that unit until told to do something else.
@@ -164,6 +141,14 @@ function CameraTrackEntities(units, zoom, seconds)
         -- Wait for it to be done
         WaitForCamera()
     end
+end
+
+--- See track entities
+---@param entity Unit
+---@param zoom number
+---@param seconds? number
+function CameraTrackEntity(entity, zoom, seconds)
+    CameraTrackEntities({entity}, zoom, seconds)
 end
 
 --- Similar to CameraTrackEntity, but this gives more control with the pitchAdjust parameter.
@@ -221,11 +206,26 @@ function CameraRevertRotation()
     ScenarioInfo.Camera:RevertRotation()
 end
 
---- Used by other functions to make sure that they don't return before the camera is done moving.
-function WaitForCamera()
-    -- Wait for it to be done
-    ScenarioInfo.Camera:WaitFor()
+--- To be used when starting a cinematic / NIS
+function EnterNISMode()
+    ScenarioInfo.Camera = SimCamera('WorldCamera')
+    LockInput()
+    ScenarioInfo.Camera:UseGameClock()
+    Sync.NISMode = 'on'
+    ScenarioInfo.OpEnded = true
+    -- Take Away UI
+    -- Set Game Speed to normal
+end
 
-    -- Reset the event tracker, so that the next camera action can be waited for
-    ScenarioInfo.Camera:EventReset()
+--- Used at the end of a cinematic / NIS
+function ExitNISMode()
+    -- Set Game Speed to user value
+    -- Restore UI
+    ScenarioInfo.OpEnded = false
+    CameraRevertRotation()
+    Sync.NISMode = 'off'
+    ScenarioInfo.Camera:UseSystemClock()
+    SetInvincible(nil, true)
+    UnlockInput()
+    ScenarioInfo.Camera = nil
 end

--- a/lua/cinematics.lua
+++ b/lua/cinematics.lua
@@ -145,7 +145,7 @@ function CameraTrackEntities(units, zoom, seconds)
     end
 end
 
---- See track entities
+--- See `CameraTrackEntities`
 ---@param entity Unit
 ---@param zoom number
 ---@param seconds? number


### PR DESCRIPTION
## Description of the proposed changes
Moved the functions around to get around the limitations of the LSP extension to fix undefined global variables

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cinematic camera handling, including more reliable waiting for camera movements to finish and proper camera event cleanup.
  - Updated cinematic scripting annotations for clearer parameter guidance.

- **Documentation**
  - Added a changelog entry describing the cinematic annotation improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->