### PR TITLE
add guard against OnDefeat failures for AI

### DIFF
--- a/changelog/snippets/ai.7256.md
+++ b/changelog/snippets/ai.7256.md
@@ -1,1 +1,1 @@
-- Add guards for platoon function calls in the DisableAI function to stop errors during the OnDefeat call.
+- Fix error when an army is defeated related to missing AI platoon functions (#7256).

--- a/changelog/snippets/ai.7256.md
+++ b/changelog/snippets/ai.7256.md
@@ -1,1 +1,1 @@
-- Add guards for platoon function calls in the DisablAI function to stop errors during the OnDefeat call.
+- Add guards for platoon function calls in the DisableAI function to stop errors during the OnDefeat call.

--- a/changelog/snippets/ai.7256.md
+++ b/changelog/snippets/ai.7256.md
@@ -1,0 +1,1 @@
+- Add guards for platoon function calls in the DisablAI function to stop errors during the OnDefeat call.

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -1437,8 +1437,12 @@ function DisableAI(self)
             if not unit.Dead then
                 local handle = unit.PlatoonHandle
                 if handle and self:PlatoonExists(handle) then
-                    handle:Stop()
-                    handle:PlatoonDisbandNoAssign()
+                    if handle.Stop then
+                        handle:Stop()
+                    end
+                    if handle.PlatoonDisbandNoAssig then
+                        handle:PlatoonDisbandNoAssign()
+                    end
                 end
                 IssueStop({ unit })
                 IssueToUnitClearCommands(unit)

--- a/lua/SimUtils.lua
+++ b/lua/SimUtils.lua
@@ -1440,7 +1440,7 @@ function DisableAI(self)
                     if handle.Stop then
                         handle:Stop()
                     end
-                    if handle.PlatoonDisbandNoAssig then
+                    if handle.PlatoonDisbandNoAssign then
                         handle:PlatoonDisbandNoAssign()
                     end
                 end


### PR DESCRIPTION

## Description of the proposed changes
There are certain niche scenarios when an AIs platoon will not have cplatoon functions available. After analyzing a replay it was found that when an AI ACU was destroyed units around it that were destroyed in the blast had a chance of being part way through the destroy state when the ondefeat function is called. 


## Testing done on the proposed changes
Tested based on a replay with the issue present. The following log watch generated.
```
warning: Error running lua script: ...forever\replaydata\gamedata\lua.nx2\lua\simutils.lua(1611): attempt to call method `Stop' (a nil value)
         stack traceback:
             ...forever\replaydata\gamedata\lua.nx2\lua\simutils.lua(1611): in function <...forever\replaydata\gamedata\lua.nx2\lua\simutils.lua:1598>
             ...aforever\replaydata\gamedata\lua.nx2\lua\aibrain.lua(445): in function `SetDefeatStatus'
             ...aforever\replaydata\gamedata\lua.nx2\lua\aibrain.lua(465): in function `OnDefeat'
             ...ua\sim\victorycondition\abstractvictorycondition.lua(406): in function `DefeatForArmy'
             ...a\lua.nx2\lua\sim\victorycondition\unitcondition.lua(62): in function `EvaluateVictoryCondition'
             ...ua\sim\victorycondition\abstractvictorycondition.lua(212): in function <...ua\sim\victorycondition\abstractvictorycondition.lua:210>
```

After adding guards the issue no longer happened and the ondefeat function could complete successfully.



## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI disable handling during defeat events by safely checking platoon functions before calling them.
  * Prevented errors when optional platoon commands are unavailable.
  * Corrected platoon disband handling so the command runs when supported.
  * Improved stability when AI-controlled armies are defeated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->