### PR TITLE
Fix chat messages not showing in replays

### DIFF
--- a/changelog/snippets/fix.7257.md
+++ b/changelog/snippets/fix.7257.md
@@ -1,0 +1,1 @@
+- Your explanation here... [Don't forget to change the category in the filename] (#7257).

--- a/changelog/snippets/fix.7257.md
+++ b/changelog/snippets/fix.7257.md
@@ -1,1 +1,1 @@
-- Your explanation here... [Don't forget to change the category in the filename] (#7257).
+- Fix chat messages not showing in replays (#7257).

--- a/lua/ui/game/chat/ChatController.lua
+++ b/lua/ui/game/chat/ChatController.lua
@@ -563,7 +563,7 @@ function Init()
     -- `RegisterChatFunc` overwrites, so re-running `Init` just rebinds
     -- the handlers.
     import("/lua/ui/game/gamemain.lua").RegisterChatFunc(OnReceive, 'Chat')
-    import("/lua/usersync.lua").AddOnSyncHashedCallback(OnSyncChatMessages, 'ChatMessages', 'Chat')
+    AddOnSyncHashedCallback(OnSyncChatMessages, 'ChatMessages', 'Chat')
     RegisterBuiltinCommands()
 
     -- Build the chat tree eagerly so the sibling feed is mounted in


### PR DESCRIPTION
## Description of the proposed changes
Fixes #7248 

The bug was that the user sync callback handler was being added using the function from the imported module instead of the global. This difference exists because `usersync.lua` is run using `doscript` in `sessioninit.lua` instead of a standard `import` call. The engine also calls the global `OnSync` function and not the `usersync.lua` module's `OnSync` function.

The reason I changed it in the first place is because I saw some error message when hot-reloading the chat controller during my testing.

## Testing done on the proposed changes
Get a recent replay with chat messages (for example #27695046).
Run the replay from faf to unpack it, then run it in the dev environment using:
```
local replay = "C:/ProgramData/FAForever/cache/temp.scfareplay"
if LaunchReplaySession(replay) then
	SetFrontEndData('replay_filename', replay)
else
	LOG(string.format('Issue starting replay "%s"', replay))
end
```
non-notify chat messages should show up.
<img width="494" height="159" alt="{C371C5C4-4AED-4174-A021-D76D42A31241}" src="https://github.com/user-attachments/assets/4cf70273-f827-435c-878c-04038c7b2a1f" />

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where chat messages did not appear during replays.
  * Improved chat message synchronization without changing expected behavior.

* **Documentation**
  * Added a changelog entry documenting the replay chat fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->