### PR TITLE
Fix DiskGetFileInfo crashing with incorrect argument

### DIFF
--- a/changelog/snippets/fix.7258.md
+++ b/changelog/snippets/fix.7258.md
@@ -1,1 +1,1 @@
-- Your explanation here... [Don't forget to change the category in the filename] (#7258).
+- Fix `DiskGetFileInfo` crashing to desktop with non-string parameters (#7258). This would rarely cause a crash when joining a lobby right as a host launches the game.

--- a/changelog/snippets/fix.7258.md
+++ b/changelog/snippets/fix.7258.md
@@ -1,0 +1,1 @@
+- Your explanation here... [Don't forget to change the category in the filename] (#7258).

--- a/engine/Core.lua
+++ b/engine/Core.lua
@@ -50,6 +50,22 @@
 -- note that these object span both the sim and user states
 ---@alias GoalObject moho.manipulator_methods | EconomyEvent | Camera
 
+---@class FileInfo
+---@field IsFolder boolean
+---@field ReadOnly boolean
+---@field SizeBytes integer
+---@field TimeStamp string # unsigned 64 bit int in lowercase hexadecimal
+---@field WriteTime FileInfo.WriteTime
+
+---@class FileInfo.WriteTime
+---@field year integer
+---@field month integer
+---@field mday integer # month day
+---@field wday integer # week day
+---@field hour integer
+---@field minute integer
+---@field second integer
+
 ---@unknown
 function AITarget()
 end
@@ -101,7 +117,7 @@ end
 
 --- returns a table of information for the given file, or `false` if the file doesn't exist
 ---@param filename FileName
----@return table | false
+---@return FileInfo | false
 function DiskGetFileInfo(filename)
 end
 

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -88,6 +88,8 @@ Prefetcher = CreatePrefetchSet()
 
 local FileCache = {}
 local oldDiskGetFileInfo = DiskGetFileInfo
+---@param file FileName
+---@return FileInfo | false
 function DiskGetFileInfo(file)
     if type(file) ~= 'string' then error('string expected but got ' .. type(file), 2) end
     if FileCache[file] == nil then

--- a/lua/userInit.lua
+++ b/lua/userInit.lua
@@ -89,6 +89,7 @@ Prefetcher = CreatePrefetchSet()
 local FileCache = {}
 local oldDiskGetFileInfo = DiskGetFileInfo
 function DiskGetFileInfo(file)
+    if type(file) ~= 'string' then error('string expected but got ' .. type(file), 2) end
     if FileCache[file] == nil then
         FileCache[file] = oldDiskGetFileInfo(file) or false
     end


### PR DESCRIPTION
## Description of the proposed changes
DiskGetFileInfo crashes with non-string arguments. The changes enforce a string argument before calling the cfunction.
Annotations for the FileInfo return type.

## Testing done on the proposed changes
- You can no longer call the function with non-string arguments.
- Used `reprsl` on the return value and checked engine code to determine annotations.

## Additional context
This is a lua-side fix for https://github.com/FAForever/FA-Binary-Patches/issues/113.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a rare crash when retrieving file information with an invalid parameter, including scenarios involving hosts joining a lobby.
  - Invalid file path inputs now produce a clear error instead of causing the game to close unexpectedly.

- **Documentation**
  - Improved documentation for file information results, including file attributes and modification timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->