### PR TITLE
Annotate formations.lua

### DIFF
--- a/changelog/snippets/category.7259.md
+++ b/changelog/snippets/category.7259.md
@@ -1,1 +1,0 @@
-- Your explanation here... [Don't forget to change the category in the filename] (#7259).

--- a/changelog/snippets/category.7259.md
+++ b/changelog/snippets/category.7259.md
@@ -1,0 +1,1 @@
+- Your explanation here... [Don't forget to change the category in the filename] (#7259).

--- a/changelog/snippets/other.7259.md
+++ b/changelog/snippets/other.7259.md
@@ -1,0 +1,1 @@
+- Annotate `formations.lua` (#7259).

--- a/engine/Core/Blueprints/EntityBlueprint.lua
+++ b/engine/Core/Blueprints/EntityBlueprint.lua
@@ -87,3 +87,4 @@
 ---@field OccupancyCaps? number
 ---@field SizeX? number
 ---@field SizeZ? number
+---@field SizeMax? integer # Added by unit blueprint postprocessing. Defaults to 1.

--- a/engine/Core/Categories.lua
+++ b/engine/Core/Categories.lua
@@ -129,6 +129,7 @@ categories = {
 
     --- Allows this unit to be built by engineers
     NEEDMOBILEBUILD = categoryValue,
+    --- Unit doesn't use a formation when assisting other units
     NOFORMATION = categoryValue,
     --- Prevents splash damage being applied to the entity
     NOSPLASHDAMAGE = categoryValue,
@@ -372,7 +373,7 @@ categories = {
 ---| "NAVALCARRIER"
 ---| "NAVAL"
 ---| "NEEDMOBILEBUILD"
----| "NOFORMATION"
+---| "NOFORMATION" # Unit doesn't use a formation when assisting other units
 ---| "NOSPLASHDAMAGE"
 ---| "NUKE"
 ---| "NUKESUB"

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -613,7 +613,6 @@ local TenWideSubAttackFormation = {
 ---@param distance Vector
 ---@return number
 function PickBestTravelFormationIndex(typeName, distance)
-    LOG(_G, 'PickBestTravelFormationIndex', typeName, distance)
     if typeName == 'AirFormations' then
         return 0
     else
@@ -630,7 +629,6 @@ end
 ---@param distance Vector
 ---@return integer | -1
 function PickBestFinalFormationIndex(typeName, distance)
-    LOG(_G, 'PickBestFinalFormationIndex', typeName, distance)
     return -1;
 end
 --#endregion

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -48,6 +48,7 @@ local ShieldCategory = import("/lua/shared/formations/categorizeunits.lua").Shie
 local NonShieldCategory = import("/lua/shared/formations/categorizeunits.lua").NonShieldCategory
 
 local CategorizeUnits = import("/lua/shared/formations/categorizeunits.lua").CategorizeUnits
+local GetDistanceBetweenTwoPoints2 = import('/lua/utilities.lua').GetDistanceBetweenTwoPoints2
 
 local TableEmpty = table.empty
 local TableGetn = table.getn
@@ -1187,7 +1188,7 @@ function GetLargeAirPositions(unitsList, airBlock)
             local blocked = false
             for i = numResults, 1, -1 do -- Don't change this to a simple forward loop or it can take 15x as long with large numbers.
                 local data = results[i]
-                if VDist2(xPos, yPos, data.xPos, data.yPos) < radius + data.size / 2 then
+                if GetDistanceBetweenTwoPoints2(xPos, yPos, data.xPos, data.yPos) < radius + data.size / 2 then
                     blocked = true
                     break
                 end

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1110,6 +1110,103 @@ end
 --#endregion
 --#region Air Block Building
 
+---@param chevronPos number
+---@param currCol number
+---@param formationLen number
+---@return number xPos
+---@return number yPos
+function GetChevronPosition(chevronPos, currCol, formationLen)
+    local offset = MathFloor(chevronPos / 2)
+    local xPos = offset * 0.5
+    if MathMod(chevronPos, 2) == 0 then
+        xPos = -xPos
+    end
+    local column = MathFloor(currCol / 2)
+    local yPos = (-offset + column * column) * 0.86603
+    yPos = yPos - formationLen * 1.73205
+    local blockOff = MathFloor(currCol / 2) * 2.5
+    if MathMod(currCol, 2) == 1 then
+        blockOff = -blockOff
+    end
+    xPos = xPos + blockOff
+    return xPos, yPos
+end
+
+---@param unitsList table<AirCategoryNames, FormationLayerFootprints> | FormationLayerCommonData
+---@param airBlock FormationBlockAir
+---@return FormationPos[]
+function GetLargeAirPositions(unitsList, airBlock)
+    local sizeCounts = {}
+    local footprintCounts = unitsList.FootprintCounts
+    for fs, count in footprintCounts do
+        local size = footprintCounts[fs]
+        if size > 1 then
+            sizeCounts[size] = (sizeCounts[size] or 0) + count
+        end
+    end
+
+    local numRows = TableGetn(airBlock)
+    local whichRow = 0
+    local whichCol = 0
+    local currRowLen = 0
+    local wideRow = false
+    local formationLength = -1
+    local results = {}
+    local numResults = 0
+    for size, count in sizeCounts do
+        local radius = size / 2
+        while count > 0 do
+            if whichCol >= currRowLen or count == 1 then
+                if whichRow >= numRows then
+                    if airBlock.RepeatAllRows then
+                        whichRow = 1
+                        currRowLen = TableGetn(airBlock[whichRow])
+                    end
+                else
+                    whichRow = whichRow + 1
+                    currRowLen = TableGetn(airBlock[whichRow])
+                end
+                formationLength = formationLength + 1
+                whichCol = 1
+                local x, y = GetChevronPosition(1, currRowLen, formationLength)
+                wideRow = MathAbs(x) >= radius
+            else
+                whichCol = whichCol + 2
+            end
+
+            if count == 2 and whichCol == 1 and wideRow then
+                continue
+            end
+
+            local xPos, yPos = GetChevronPosition(1, whichCol, formationLength)
+            if whichCol ~= 1 and MathAbs(xPos) < radius then
+                continue
+            end
+
+            -- Exponential complexity isn't fun but this should run in under 0.03 seconds on a slow CPU with 500 CZARs.
+            local blocked = false
+            for i = numResults, 1, -1 do -- Don't change this to a simple forward loop or it can take 15x as long with large numbers.
+                local data = results[i]
+                if VDist2(xPos, yPos, data.xPos, data.yPos) < radius + data.size / 2 then
+                    blocked = true
+                    break
+                end
+            end
+            if not blocked then
+                TableInsert(results, {row = whichRow, col = whichCol, xPos = xPos, yPos = yPos, size = size})
+                count = count - 1
+                numResults = numResults + 1
+                if whichCol ~= 1 then
+                    TableInsert(results, {row = whichRow, col = whichCol - 1, xPos = -xPos, yPos = yPos, size = size})
+                    count = count - 1
+                    numResults = numResults + 1
+                end
+            end
+        end
+    end
+    return results
+end
+
 ---@param unitsList table<AirCategoryNames, FormationLayerFootprints> | FormationLayerCommonData
 ---@param airBlock FormationBlockAir # ChevronSize defaults to 5
 ---@param spacing? number defaults to 1
@@ -1326,101 +1423,5 @@ function BlockBuilderAirT3Bombers(unitsList, spacing)
     return FormationPos
 end
 
----@param unitsList table<AirCategoryNames, FormationLayerFootprints> | FormationLayerCommonData
----@param airBlock FormationBlockAir
----@return FormationPos[]
-function GetLargeAirPositions(unitsList, airBlock)
-    local sizeCounts = {}
-    local footprintCounts = unitsList.FootprintCounts
-    for fs, count in footprintCounts do
-        local size = footprintCounts[fs]
-        if size > 1 then
-            sizeCounts[size] = (sizeCounts[size] or 0) + count
-        end
-    end
-
-    local numRows = TableGetn(airBlock)
-    local whichRow = 0
-    local whichCol = 0
-    local currRowLen = 0
-    local wideRow = false
-    local formationLength = -1
-    local results = {}
-    local numResults = 0
-    for size, count in sizeCounts do
-        local radius = size / 2
-        while count > 0 do
-            if whichCol >= currRowLen or count == 1 then
-                if whichRow >= numRows then
-                    if airBlock.RepeatAllRows then
-                        whichRow = 1
-                        currRowLen = TableGetn(airBlock[whichRow])
-                    end
-                else
-                    whichRow = whichRow + 1
-                    currRowLen = TableGetn(airBlock[whichRow])
-                end
-                formationLength = formationLength + 1
-                whichCol = 1
-                local x, y = GetChevronPosition(1, currRowLen, formationLength)
-                wideRow = MathAbs(x) >= radius
-            else
-                whichCol = whichCol + 2
-            end
-
-            if count == 2 and whichCol == 1 and wideRow then
-                continue
-            end
-
-            local xPos, yPos = GetChevronPosition(1, whichCol, formationLength)
-            if whichCol ~= 1 and MathAbs(xPos) < radius then
-                continue
-            end
-
-            -- Exponential complexity isn't fun but this should run in under 0.03 seconds on a slow CPU with 500 CZARs.
-            local blocked = false
-            for i = numResults, 1, -1 do -- Don't change this to a simple forward loop or it can take 15x as long with large numbers.
-                local data = results[i]
-                if VDist2(xPos, yPos, data.xPos, data.yPos) < radius + data.size / 2 then
-                    blocked = true
-                    break
-                end
-            end
-            if not blocked then
-                TableInsert(results, {row = whichRow, col = whichCol, xPos = xPos, yPos = yPos, size = size})
-                count = count - 1
-                numResults = numResults + 1
-                if whichCol ~= 1 then
-                    TableInsert(results, {row = whichRow, col = whichCol - 1, xPos = -xPos, yPos = yPos, size = size})
-                    count = count - 1
-                    numResults = numResults + 1
-                end
-            end
-        end
-    end
-    return results
-end
-
----@param chevronPos number
----@param currCol number
----@param formationLen number
----@return number xPos
----@return number yPos
-function GetChevronPosition(chevronPos, currCol, formationLen)
-    local offset = MathFloor(chevronPos / 2)
-    local xPos = offset * 0.5
-    if MathMod(chevronPos, 2) == 0 then
-        xPos = -xPos
-    end
-    local column = MathFloor(currCol / 2)
-    local yPos = (-offset + column * column) * 0.86603
-    yPos = yPos - formationLen * 1.73205
-    local blockOff = MathFloor(currCol / 2) * 2.5
-    if MathMod(currCol, 2) == 1 then
-        blockOff = -blockOff
-    end
-    xPos = xPos + blockOff
-    return xPos, yPos
-end
 --#endregion
 --#endregion

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -866,6 +866,118 @@ function GuardFormation(formationUnits)
 end
 
 -- =========== LAND BLOCK BUILDING =================
+
+---@param unitsList table<LandCategoryNames | NavalCategoryNames | SubCategoryNames, FormationLayerFootprints> | FormationLayerCommonData
+---@param categoryTable EntityCategory[]
+---@param currRowLen number
+---@return number
+function GetLandRowModifer(unitsList, categoryTable, currRowLen)
+    local unitTotal = unitsList.UnitTotal
+    if unitTotal >= currRowLen or MathMod(unitTotal, 2) == MathMod(currRowLen, 2) then
+        return 0
+    end
+
+    local sizeTotal = 0
+    local footprintSizes = unitsList.FootprintSizes
+    for group, _ in categoryTable do
+        for fs, data in unitsList[group] do
+            sizeTotal = sizeTotal + footprintSizes[fs] * data.Count
+        end
+    end
+    if sizeTotal < currRowLen then -- This doesn't allow for large units hanging over the sides, but it's too hard to handle that correctly.
+        return 1
+    else
+        return 0
+    end
+end
+
+---@param occupiedSpaces boolean[][]
+---@param size number
+---@param rowNum number
+---@param whichCol number
+---@param currRowLen number
+---@param remainingUnits number
+---@return boolean
+function IsLandSpaceOccupied(occupiedSpaces, size, rowNum, whichCol, currRowLen, remainingUnits)
+    local evenRowLen = MathMod(currRowLen, 2) == 0
+    local evenSize = MathMod(size, 2) == 0
+
+    if whichCol == 1 and (not evenRowLen) and evenSize and remainingUnits > 1 then -- Don't put an even-sized unit in the middle of an odd-length row unless it's the last unit
+        return true
+    end
+    if whichCol > currRowLen - MathFloor(size / 2) * 2 and size <= MathFloor(currRowLen / 2) then -- Don't put a large unit at the end of a row unless the row is too narrow
+        return true
+    end
+    for y = 0, size - 1, 1 do
+        local yPos = rowNum + y
+        if not occupiedSpaces[yPos] then
+            continue
+        end
+        if whichCol == 1 and evenRowLen == evenSize then
+            for x = 0, size - 1, 1 do
+                if occupiedSpaces[yPos][whichCol + x] then
+                    return true
+                end
+            end
+        else
+            for x = 0, (size - 1) * 2, 2 do
+                if occupiedSpaces[yPos][whichCol + x] then
+                    return true
+                end
+            end
+        end
+    end
+    return false
+end
+
+---@param occupiedSpaces boolean[][]
+---@param size number
+---@param rowNum number
+---@param whichCol number
+---@param currRowLen number
+function OccupyLandSpace(occupiedSpaces, size, rowNum, whichCol, currRowLen)
+    local evenRowLen = MathMod(currRowLen, 2) == 0
+    local evenSize = MathMod(size, 2) == 0
+
+    for y = 0, size - 1, 1 do
+        local yPos = rowNum + y
+        if not occupiedSpaces[yPos] then
+            occupiedSpaces[yPos] = {}
+        end
+        local occupiedYPos = occupiedSpaces[yPos]
+        if whichCol == 1 and evenRowLen == evenSize then
+            for x = 0, size - 1, 1 do
+                occupiedYPos[whichCol + x] = true
+            end
+        else
+            for x = 0, (size - 1) * 2, 2 do
+                occupiedYPos[whichCol + x] = true
+            end
+        end
+    end
+end
+
+---@param rowLen number
+---@param col number
+---@return number
+function GetColSpot(rowLen, col)
+    local len = rowLen
+    if MathMod(rowLen, 2) == 1 then
+        len = rowLen + 1
+    end
+    local colType = 'left'
+    if MathMod(col, 2) == 0 then
+        colType = 'right'
+    end
+    local colSpot = MathFloor(col / 2)
+    local halfSpot = len/2
+    if colType == 'left' then
+        return halfSpot - colSpot
+    else
+        return halfSpot + colSpot
+    end
+end
+
 ---@param unitsList table<LandCategoryNames | NavalCategoryNames | SubCategoryNames, FormationLayerFootprints> | FormationLayerCommonData
 ---@param formationBlock FormationBlockLand
 ---@param categoryTable EntityCategory[]
@@ -994,117 +1106,6 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable)
     end
 
     return FormationPos
-end
-
----@param unitsList table<LandCategoryNames | NavalCategoryNames | SubCategoryNames, FormationLayerFootprints> | FormationLayerCommonData
----@param categoryTable EntityCategory[]
----@param currRowLen number
----@return number
-function GetLandRowModifer(unitsList, categoryTable, currRowLen)
-    local unitTotal = unitsList.UnitTotal
-    if unitTotal >= currRowLen or MathMod(unitTotal, 2) == MathMod(currRowLen, 2) then
-        return 0
-    end
-
-    local sizeTotal = 0
-    local footprintSizes = unitsList.FootprintSizes
-    for group, _ in categoryTable do
-        for fs, data in unitsList[group] do
-            sizeTotal = sizeTotal + footprintSizes[fs] * data.Count
-        end
-    end
-    if sizeTotal < currRowLen then -- This doesn't allow for large units hanging over the sides, but it's too hard to handle that correctly.
-        return 1
-    else
-        return 0
-    end
-end
-
----@param occupiedSpaces boolean[][]
----@param size number
----@param rowNum number
----@param whichCol number
----@param currRowLen number
----@param remainingUnits number
----@return boolean
-function IsLandSpaceOccupied(occupiedSpaces, size, rowNum, whichCol, currRowLen, remainingUnits)
-    local evenRowLen = MathMod(currRowLen, 2) == 0
-    local evenSize = MathMod(size, 2) == 0
-
-    if whichCol == 1 and (not evenRowLen) and evenSize and remainingUnits > 1 then -- Don't put an even-sized unit in the middle of an odd-length row unless it's the last unit
-        return true
-    end
-    if whichCol > currRowLen - MathFloor(size / 2) * 2 and size <= MathFloor(currRowLen / 2) then -- Don't put a large unit at the end of a row unless the row is too narrow
-        return true
-    end
-    for y = 0, size - 1, 1 do
-        local yPos = rowNum + y
-        if not occupiedSpaces[yPos] then
-            continue
-        end
-        if whichCol == 1 and evenRowLen == evenSize then
-            for x = 0, size - 1, 1 do
-                if occupiedSpaces[yPos][whichCol + x] then
-                    return true
-                end
-            end
-        else
-            for x = 0, (size - 1) * 2, 2 do
-                if occupiedSpaces[yPos][whichCol + x] then
-                    return true
-                end
-            end
-        end
-    end
-    return false
-end
-
----@param occupiedSpaces boolean[][]
----@param size number
----@param rowNum number
----@param whichCol number
----@param currRowLen number
-function OccupyLandSpace(occupiedSpaces, size, rowNum, whichCol, currRowLen)
-    local evenRowLen = MathMod(currRowLen, 2) == 0
-    local evenSize = MathMod(size, 2) == 0
-
-    for y = 0, size - 1, 1 do
-        local yPos = rowNum + y
-        if not occupiedSpaces[yPos] then
-            occupiedSpaces[yPos] = {}
-        end
-        local occupiedYPos = occupiedSpaces[yPos]
-        if whichCol == 1 and evenRowLen == evenSize then
-            for x = 0, size - 1, 1 do
-                occupiedYPos[whichCol + x] = true
-            end
-        else
-            for x = 0, (size - 1) * 2, 2 do
-                occupiedYPos[whichCol + x] = true
-            end
-        end
-    end
-end
-
----@param rowLen number
----@param col number
----@return number
-function GetColSpot(rowLen, col)
-    local len = rowLen
-    if MathMod(rowLen, 2) == 1 then
-        len = rowLen + 1
-    end
-    local colType = 'left'
-    if MathMod(col, 2) == 0 then
-        colType = 'right'
-    end
-    local colSpot = MathFloor(col / 2)
-    local halfSpot = len/2
-    if colType == 'left' then
-        return halfSpot - colSpot
-    else
-        return halfSpot + colSpot
-    end
 end
 
 -- ============ AIR BLOCK BUILDING =============

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -62,6 +62,9 @@ ComboFormations = {
 
 ---@type FormationPos[]
 local FormationPos = {} -- list to be returned
+
+--#region Formation caching
+
 local FormationCache = {}
 local MaxCacheSize = 30
 
@@ -107,13 +110,14 @@ function CacheResults(results, formationUnits, formationType)
     end
     TableInsert(cache, 1, {Results = results, Units = formationUnits, UnitCount = TableGetn(formationUnits)})
 end
+--#endregion
+--#region Formation Block Data
+--#region Land Data
 
--- =========================================
--- ================ LAND DATA ==============
--- =========================================
 local RemainingCategory = { 'RemainingCategory', }
 
--- === SUB GROUP ORDERING ===
+--#region Subgroup ordering
+
 local Bots = { 'Bot4', 'Bot3', 'Bot2', 'Bot1', }
 local Tanks = { 'Tank4', 'Tank3', 'Tank2', 'Tank1', }
 local DF = { 'Tank4', 'Bot4', 'Tank3', 'Bot3', 'Tank2', 'Bot2', 'Tank1', 'Bot1', }
@@ -123,17 +127,17 @@ local AA = { 'AA3', 'AA2', 'AA1', }
 local Util = { 'Util4', 'Util3', 'Util2', 'Util1', }
 local Com = { 'Com4', 'Com3', 'Com2', 'Com1', }
 local Shield = { 'Shields', }
+--#endregion
+--#region Land Block Types
 
--- === LAND BLOCK TYPES =
 local DFFirst = { DF, T1Art, AA, Shield, Com, Util, RemainingCategory }
 local ShieldFirst = { Shield, AA, DF, T1Art, Com, Util, RemainingCategory }
 local AAFirst = { AA, DF, T1Art, Shield, Com, Util, RemainingCategory }
 local ArtFirst = { Art, DF, AA, Shield, Com, Util, RemainingCategory }
 local T1ArtFirst = { T1Art, DF, AA, Shield, Com, Util, RemainingCategory }
 local UtilFirst = { Util, AA, Shield, DF, T1Art, Com, RemainingCategory }
-
-
--- === LAND BLOCKS ===
+--#endregion
+--#region Land Blocks
 
 -- === 3 Wide Attack Block / 3 Units ===
 local ThreeWideAttackFormationBlock = {
@@ -308,12 +312,11 @@ local EightRowAttackFormationBlock = {
     -- eight row
     { AAFirst, ShieldFirst, ArtFirst, AAFirst, ShieldFirst, ArtFirst, ShieldFirst, AAFirst, ShieldFirst, ArtFirst, ArtFirst, ShieldFirst, AAFirst, ShieldFirst, ArtFirst, ShieldFirst, AAFirst, ArtFirst, ShieldFirst, AAFirst },
 }
+--#endregion
+--#endregion
+--#region Air Data
+--#region Subgroup Ordering
 
--- =========================================
--- ================ AIR DATA ===============
--- =========================================
-
--- === SUB GROUP ORDERING ===
 local GroundAttack = { 'Ground3', 'Ground2', 'Ground1', }
 local Transports = { 'Trans3', 'Trans2', 'Trans1', }
 local Bombers = { 'Bomb3', 'Bomb2', 'Bomb1', }
@@ -323,8 +326,9 @@ local AntiNavy = { 'AN3', 'AN2', 'AN1', }
 local Intel = { 'AIntel3', 'AIntel2', 'AIntel1', }
 local ExperAir = { 'AExper', }
 local EngAir = { 'AEngineer', }
+--#endregion
+--#region Air Block Arrangement
 
--- === Air Block Arrangement ===
 local ChevronSlot = { AntiAir, ExperAir, AntiNavy, GroundAttack, Bombers, Intel, Transports, EngAir, RemainingCategory }
 local StratSlot = { T3Bombers }
 
@@ -380,14 +384,12 @@ local GrowthChevronBlock = {
     { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, },
     { ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, ChevronSlot, }, -- 7 -> 9 at 545 units
 }
+--#endregion
+--#endregion
+--#region Naval Data
 
+--#region Subgroup Ordering
 
-
--- =========================================
--- ============== NAVAL DATA ===============
--- =========================================
-
--- === SUB GROUP ORDERING ===
 local Frigates = { 'FrigateCount', 'LightCount', }
 local Destroyers = { 'DestroyerCount', }
 local Cruisers = { 'CruiserCount', }
@@ -396,8 +398,9 @@ local Subs = { 'SubCount', }
 local NukeSubs = { 'NukeSubCount', }
 local Carriers = { 'CarrierCount', }
 local Sonar = {'MobileSonarCount', }
+--#endregion
+--#region Naval Block Types
 
--- === NAVAL BLOCK TYPES =
 local FrigatesFirst = { Frigates, Destroyers, Battleships, Cruisers, Carriers, NukeSubs, Sonar, RemainingCategory }
 local DestroyersFirst = { Destroyers, Frigates, Battleships, Cruisers, Carriers, NukeSubs, Sonar, RemainingCategory }
 local CruisersFirst = { Cruisers, Carriers, Battleships, Destroyers, Frigates, NukeSubs, Sonar, RemainingCategory }
@@ -407,8 +410,8 @@ local LargestFirstAA = { Carriers, Battleships, Cruisers, Destroyers, Frigates, 
 local SmallestFirstAA = { Cruisers, Frigates, Destroyers, Sonar, Carriers, Battleships, NukeSubs, RemainingCategory }
 local Subs = { Subs, NukeSubs, RemainingCategory }
 local SonarFirst = { Sonar, Carriers, Cruisers, Battleships, Destroyers, Frigates, NukeSubs, Sonar, RemainingCategory }
-
--- === NAVAL BLOCKS ===
+--#endregion
+--#region Naval Blocks
 
 -- === Three Naval Growth Formation Block ==
 local ThreeNavalGrowthFormation = {
@@ -470,10 +473,8 @@ local NineNavalGrowthFormation = {
     -- fifth row
     { DestroyersFirst, DestroyersFirst, SmallestFirstAA, SmallestFirstAA, CruisersFirst, SmallestFirstAA, SmallestFirstAA, DestroyersFirst, DestroyersFirst },
 }
-
--- ==============================================
--- ============ Naval Attack Formation===========
--- ==============================================
+--#endregion
+--#region Naval Attack Formation
 
 -- === Five Wide Naval Attack Formation Block ==
 local FiveWideNavalAttackFormation = {
@@ -520,10 +521,9 @@ local ElevenWideNavalAttackFormation = {
     -- fourth row
     { DestroyersFirst, SmallestFirstAA, LargestFirstDF, SonarFirst, LargestFirstAA, CruisersFirst, LargestFirstAA, SonarFirst, LargestFirstDF, SmallestFirstAA, DestroyersFirst },
 }
+--#endregion
+--#region Sub Growth Formation
 
--- ==============================================
--- ============ Sub Growth Formation===========
--- ==============================================
 -- === Four Wide Growth Subs Formation ===
 local FourWideSubGrowthFormation = {
     LineBreak = 0.5,
@@ -547,11 +547,8 @@ local EightWideSubGrowthFormation = {
     { Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs },
     { Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs },
 }
-
-
--- ==============================================
--- ============ Sub Attack Formation===========
--- ==============================================
+--#endregion
+--#region Sub Attack Formation
 
 -- === Four Wide Subs Formation ===
 local FourWideSubAttackFormation = {
@@ -585,8 +582,10 @@ local TenWideSubAttackFormation = {
     { Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs },
     { Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs, Subs },
 }
-
--- ============ Formation Pickers ============
+--#endregion
+--#endregion
+--#endregion
+--#region UI-Side Formation Pickers
 
 --- Called by the engine to determine which formation to use for user orders while traveling (distance > 200).
 --- 
@@ -615,10 +614,9 @@ function PickBestFinalFormationIndex(typeName, distance)
     LOG(_G, 'PickBestFinalFormationIndex', typeName, distance)
     return -1;
 end
+--#endregion
+--#region Sim-Side Formation Functions
 
--- ================ THE GUTS ====================
--- ============ Formation Functions =============
--- ==============================================
 ---@param formationUnits Unit[]
 ---@return FormationPos[]
 function AttackFormation(formationUnits)
@@ -1404,3 +1402,4 @@ function GetChevronPosition(chevronPos, currCol, formationLen)
     xPos = xPos + blockOff
     return xPos, yPos
 end
+--#endregion

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -23,6 +23,24 @@
 ---@field [4] integer # moveDelay: engine initiates pathfinding with a delay, with lower numbers going first
 ---@field [5] boolean # rotate: unknown 
 
+---@class FormationBlock
+---@field [integer] FormationBlockType[] # Row, column format
+
+---@class FormationBlockType
+---@field [integer] FormationSubgroup
+
+---@class FormationSubgroup
+---@field [integer] FormationCategoryNames
+
+---@class FormationBlockAir : FormationBlock
+---@field RepeatAllRows? boolean
+---@field HomogenousBlocks? boolean
+---@field ChevronSize? number
+
+---@class FormationBlockLand : FormationBlock
+---@field LineBreak? number
+---@field HomogenousRows? boolean
+
 local LandCategories = import("/lua/shared/formations/categorizeunits.lua").LandCategories
 local NavalCategories = import("/lua/shared/formations/categorizeunits.lua").NavalCategories
 local SubCategories = import("/lua/shared/formations/categorizeunits.lua").SubCategories
@@ -848,8 +866,8 @@ function GuardFormation(formationUnits)
 end
 
 -- =========== LAND BLOCK BUILDING =================
----@param unitsList table
----@param formationBlock any
+---@param unitsList table<LandCategoryNames | NavalCategoryNames | SubCategoryNames, FormationLayerFootprints> | FormationLayerCommonData
+---@param formationBlock FormationBlockLand
 ---@param categoryTable EntityCategory[]
 ---@return FormationPos[]
 function BlockBuilderLand(unitsList, formationBlock, categoryTable)
@@ -978,7 +996,7 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable)
     return FormationPos
 end
 
----@param unitsList table
+---@param unitsList table<LandCategoryNames | NavalCategoryNames | SubCategoryNames, FormationLayerFootprints> | FormationLayerCommonData
 ---@param categoryTable EntityCategory[]
 ---@param currRowLen number
 ---@return number
@@ -1090,8 +1108,8 @@ function GetColSpot(rowLen, col)
 end
 
 -- ============ AIR BLOCK BUILDING =============
----@param unitsList table
----@param airBlock any
+---@param unitsList table<AirCategoryNames, FormationLayerFootprints> | FormationLayerCommonData
+---@param airBlock FormationBlockAir # ChevronSize defaults to 5
 ---@param spacing? number defaults to 1
 ---@return FormationPos[]
 function BlockBuilderAir(unitsList, airBlock, spacing)
@@ -1199,7 +1217,7 @@ function BlockBuilderAir(unitsList, airBlock, spacing)
     return FormationPos
 end
 
----@param unitsList table
+---@param unitsList table<AirCategoryNames, FormationLayerFootprints> | FormationLayerCommonData
 ---@param spacing number? number defaults to 1
 ---@return FormationPos[]
 function BlockBuilderAirT3Bombers(unitsList, spacing)
@@ -1207,7 +1225,7 @@ function BlockBuilderAirT3Bombers(unitsList, spacing)
     --Some parts can be improved, but I just want stable and working version, so I did minimum adjustments and that's it.
 
     spacing = (spacing or 1) * unitsList.Scale
-    local airBlock = {}
+    local airBlock ---@type FormationBlockAir
 
     if unitsList.Bomb3[1].Count > 20 then
         airBlock = {
@@ -1306,8 +1324,8 @@ function BlockBuilderAirT3Bombers(unitsList, spacing)
     return FormationPos
 end
 
----@param unitsList table
----@param airBlock any
+---@param unitsList table<AirCategoryNames, FormationLayerFootprints> | FormationLayerCommonData
+---@param airBlock FormationBlockAir
 ---@return FormationPos[]
 function GetLargeAirPositions(unitsList, airBlock)
     local sizeCounts = {}

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -12,6 +12,17 @@
 
 ---@alias UnitFormations 'AttackFormation' | 'GrowthFormation' | 'NoFormation' | 'None' | 'none'
 
+--- Table names that the engine accesses to get formation function names
+--- based on the motion type of the units a formation is being made for.
+---@alias FormationType 'SurfaceFormations' | 'AirFormations' | 'ComboFormations'
+
+---@class FormationPos
+---@field [1] number # xPos
+---@field [2] number # yPos
+---@field [3] EntityCategory # Category filter to use to assign units
+---@field [4] integer # moveDelay: engine initiates pathfinding with a delay, with lower numbers going first
+---@field [5] boolean # rotate: unknown 
+
 local LandCategories = import("/lua/shared/formations/categorizeunits.lua").LandCategories
 local NavalCategories = import("/lua/shared/formations/categorizeunits.lua").NavalCategories
 local SubCategories = import("/lua/shared/formations/categorizeunits.lua").SubCategories
@@ -49,6 +60,7 @@ ComboFormations = {
     'GrowthFormation',
 }
 
+---@type FormationPos[]
 local FormationPos = {} -- list to be returned
 local FormationCache = {}
 local MaxCacheSize = 30
@@ -81,7 +93,7 @@ function GetCachedResults(formationUnits, formationType)
     return false
 end
 
----@param results TLaserBotProjectile
+---@param results FormationPos[]
 ---@param formationUnits Unit[]
 ---@param formationType UnitFormations
 function CacheResults(results, formationUnits, formationType)
@@ -597,7 +609,7 @@ end
 -- ============ Formation Functions =============
 -- ==============================================
 ---@param formationUnits Unit[]
----@return table
+---@return FormationPos[]
 function AttackFormation(formationUnits)
     local cachedResults = GetCachedResults(formationUnits, 'AttackFormation')
     if cachedResults then
@@ -656,7 +668,7 @@ function AttackFormation(formationUnits)
 end
 
 ---@param formationUnits Unit[]
----@return table
+---@return FormationPos[]
 function GrowthFormation(formationUnits)
     local cachedResults = GetCachedResults(formationUnits, 'GrowthFormation')
     if cachedResults then
@@ -741,7 +753,7 @@ function GrowthFormation(formationUnits)
 end
 
 ---@param formationUnits Unit[]
----@return table
+---@return FormationPos[]
 function GuardFormation(formationUnits)
     -- Not worth caching GuardFormation because it's almost never called repeatedly with the same units.
     local FormationPos = {}
@@ -830,7 +842,7 @@ end
 ---@param unitsList table
 ---@param formationBlock any
 ---@param categoryTable EntityCategory[]
----@return table
+---@return FormationPos[]
 function BlockBuilderLand(unitsList, formationBlock, categoryTable)
     local spacing = unitsList.Scale
     local numRows = TableGetn(formationBlock)
@@ -1072,7 +1084,7 @@ end
 ---@param unitsList table
 ---@param airBlock any
 ---@param spacing? number defaults to 1
----@return table
+---@return FormationPos[]
 function BlockBuilderAir(unitsList, airBlock, spacing)
     spacing = (spacing or 1) * unitsList.Scale
     local numRows = TableGetn(airBlock)
@@ -1180,7 +1192,7 @@ end
 
 ---@param unitsList table
 ---@param spacing number? number defaults to 1
----@return table
+---@return FormationPos[]
 function BlockBuilderAirT3Bombers(unitsList, spacing)
     --This is modified copy of BlockBuilderAir(). This function is used only for t3 bombers.
     --Some parts can be improved, but I just want stable and working version, so I did minimum adjustments and that's it.
@@ -1287,7 +1299,7 @@ end
 
 ---@param unitsList table
 ---@param airBlock any
----@return table
+---@return FormationPos[]
 function GetLargeAirPositions(unitsList, airBlock)
     local sizeCounts = {}
     local footprintCounts = unitsList.FootprintCounts

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -587,21 +587,30 @@ local TenWideSubAttackFormation = {
 }
 
 -- ============ Formation Pickers ============
----@param typeName string
+
+--- Called by the engine to determine which formation to use for user orders while traveling (distance > 200).
+--- 
+--- Seems to have no effect.
+---@param typeName FormationType
 ---@param distance Vector
 ---@return number
 function PickBestTravelFormationIndex(typeName, distance)
     LOG(_G, 'PickBestTravelFormationIndex', typeName, distance)
     if typeName == 'AirFormations' then
-        return 0;
+        return 0
     else
-        return 1;
+        return 1
     end
 end
 
----@param typeName string
+--- Called by the engine to determine which final formation to default to for user orders.
+--- 
+--- Return -1 to use the user's last used formation.
+--- 
+--- Silently fails on errors.
+---@param typeName FormationType
 ---@param distance Vector
----@return number
+---@return integer | -1
 function PickBestFinalFormationIndex(typeName, distance)
     LOG(_G, 'PickBestFinalFormationIndex', typeName, distance)
     return -1;

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -865,7 +865,7 @@ function GuardFormation(formationUnits)
     return FormationPos
 end
 
--- =========== LAND BLOCK BUILDING =================
+--#region Land Block Building
 
 ---@param unitsList table<LandCategoryNames | NavalCategoryNames | SubCategoryNames, FormationLayerFootprints> | FormationLayerCommonData
 ---@param categoryTable EntityCategory[]
@@ -1107,8 +1107,9 @@ function BlockBuilderLand(unitsList, formationBlock, categoryTable)
 
     return FormationPos
 end
+--#endregion
+--#region Air Block Building
 
--- ============ AIR BLOCK BUILDING =============
 ---@param unitsList table<AirCategoryNames, FormationLayerFootprints> | FormationLayerCommonData
 ---@param airBlock FormationBlockAir # ChevronSize defaults to 5
 ---@param spacing? number defaults to 1
@@ -1421,4 +1422,5 @@ function GetChevronPosition(chevronPos, currCol, formationLen)
     xPos = xPos + blockOff
     return xPos, yPos
 end
+--#endregion
 --#endregion

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1381,7 +1381,7 @@ function GetLargeAirPositions(unitsList, airBlock)
     return results
 end
 
----@param chevronPos Vector
+---@param chevronPos number
 ---@param currCol number
 ---@param formationLen number
 ---@return number xPos

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -591,6 +591,7 @@ local TenWideSubAttackFormation = {
 ---@param distance Vector
 ---@return number
 function PickBestTravelFormationIndex(typeName, distance)
+    LOG(_G, 'PickBestTravelFormationIndex', typeName, distance)
     if typeName == 'AirFormations' then
         return 0;
     else
@@ -602,6 +603,7 @@ end
 ---@param distance Vector
 ---@return number
 function PickBestFinalFormationIndex(typeName, distance)
+    LOG(_G, 'PickBestFinalFormationIndex', typeName, distance)
     return -1;
 end
 

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1356,7 +1356,7 @@ function BlockBuilderAirT3Bombers(unitsList, spacing)
     local chevronPos = 1
     local currRowLen = TableGetn(airBlock[whichRow])
     local chevronSize = 1
-    local chevronType = false
+    local chevronType = false ---@type false | FormationSubgroup
     local formationLength = 0
 
 

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1135,7 +1135,7 @@ end
 
 ---@param unitsList table<AirCategoryNames, FormationLayerFootprints> | FormationLayerCommonData
 ---@param airBlock FormationBlockAir
----@return FormationPos[]
+---@return FormationLargeAirPos[]
 function GetLargeAirPositions(unitsList, airBlock)
     local sizeCounts = {}
     local footprintCounts = unitsList.FootprintCounts
@@ -1152,7 +1152,7 @@ function GetLargeAirPositions(unitsList, airBlock)
     local currRowLen = 0
     local wideRow = false
     local formationLength = -1
-    local results = {}
+    local results = {} ---@type FormationLargeAirPos[]
     local numResults = 0
     for size, count in sizeCounts do
         local radius = size / 2
@@ -1194,6 +1194,13 @@ function GetLargeAirPositions(unitsList, airBlock)
                 end
             end
             if not blocked then
+                ---@class FormationLargeAirPos
+                ---@field row integer
+                ---@field col integer
+                ---@field xPos number
+                ---@field yPos number
+                ---@field size integer # footprint size max
+
                 TableInsert(results, {row = whichRow, col = whichCol, xPos = xPos, yPos = yPos, size = size})
                 count = count - 1
                 numResults = numResults + 1

--- a/lua/shared/formations/categorizeUnits.lua
+++ b/lua/shared/formations/categorizeUnits.lua
@@ -11,6 +11,8 @@ local UtilityCat = (((categories.RADAR + categories.COUNTERINTELLIGENCE) - categ
 ShieldCategory = categories.uel0307 + categories.ual0307 + categories.xsl0307
 NonShieldCategory = categories.ALLUNITS - ShieldCategory
 
+---@alias FormationCategoryNames LandCategoryNames | NavalCategoryNames | AirCategoryNames | SubCategoryNames
+
 ---@alias LandCategoryNames
 ---| "Shields"
 ---| "Bot1"

--- a/lua/utilities.lua
+++ b/lua/utilities.lua
@@ -211,7 +211,7 @@ function GetDistanceBetweenTwoPoints(x1, y1, z1, x2, y2, z2)
     return MathSqrt(dx*dx + dy*dy + dz*dz)
 end
 
----@see GetDistanceBetweenTwoPoints(x1, z1, x2, z2) # for a 3D option
+---@see GetDistanceBetweenTwoPoints(x1, y1, z1, x2, y2, z2) # for a 3D option
 ---@see XZDistanceTwoVectors(v1, v2) # for a vector option
 ---@param x1 number
 ---@param z1 number


### PR DESCRIPTION
## Description of the proposed changes
Annotates the file and anything related.

## Testing done on the proposed changes
No annotation warnings in the file and all the functions have distinct parameters.
The regions open/close correctly and are useful.
I found NOFORMATION in the engine.
Used debug logging and engine decompilation to confirm that the formation pickers are only called UI-side.

## Additional Context
I didn't look at #5908 although it should be pretty good to crossreference.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formation positioning for large air units.
  * Corrected formation distance calculations and handling of formation data.
  * Added clearer categorization for units that do not use formations while assisting others.

* **Documentation**
  * Expanded formation-related annotations and clarified blueprint fields.
  * Corrected and improved distance utility documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->