### PR TITLE
Add AssignUnitToPlatoon function with cached table to reduce table allocations

### DIFF
--- a/changelog/snippets/ai.7260.md
+++ b/changelog/snippets/ai.7260.md
@@ -1,1 +1,1 @@
-- Adds `aibrain:AssignUnitToPlatoon()` function for a single unit, the table passed to `AssignUnitsToPlatoon` is cached and just the single unit swapped, just like `IssueToUnit` commads work.
+- Adds `aibrain:AssignUnitToPlatoon()` function for a single unit, the table passed to `AssignUnitsToPlatoon` is cached and just the single unit swapped, just like `IssueToUnit` commads work (#7260).

--- a/changelog/snippets/ai.7260.md
+++ b/changelog/snippets/ai.7260.md
@@ -1,1 +1,1 @@
-- Adds `aibrain:AssignUnitToPlatoon()` function for a single unit, the table passed to `AssignUnitsToPlatoon` is cached and just the single unit swapped, just like `IssueToUnit` commads work (#7260).
+- Add `aibrain:AssignUnitToPlatoon()` function for a single unit, where the table passed to `AssignUnitsToPlatoon` is cached and just the single unit swapped, just like how the `IssueToUnit` commands work (#7260).

--- a/changelog/snippets/ai.7260.md
+++ b/changelog/snippets/ai.7260.md
@@ -1,0 +1,1 @@
+- Adds `aibrain:AssignUnitToPlatoon()` function for a single unit, the table passed to `AssignUnitsToPlatoon` is cached and just the single unit swapped, just like `IssueToUnit` commads work.

--- a/engine/Sim/CAiBrain.lua
+++ b/engine/Sim/CAiBrain.lua
@@ -26,12 +26,13 @@ local CAiBrain = {}
 function CAiBrain:AssignThreatAtPosition(position, threat, decay, threatType)
 end
 
---- Assigns a unit to a platoon
+--- Assigns units to a platoon
 ---@param platoon moho.platoon_methods | string Either a reference to a platoon, or the unique name of the platoon
----@param unit Unit
+---@param units Unit[]
 ---@param squad PlatoonSquads
 ---@param formation UnitFormations
-function CAiBrain:AssignUnitsToPlatoon(platoon, unit, squad, formation)
+---@return UnitFormations #Returns the name of the formation
+function CAiBrain:AssignUnitsToPlatoon(platoon, units, squad, formation)
 end
 
 --- Orders factories to build a platoon.

--- a/lua/AI/AIBehaviors.lua
+++ b/lua/AI/AIBehaviors.lua
@@ -37,7 +37,7 @@ function CDRRunAway(aiBrain, cdr)
             local canTeleport = cdr:HasEnhancement('Teleporter')
             local runSpot, prevSpot
             local plat = aiBrain:MakePlatoon('', '')
-            aiBrain:AssignUnitsToPlatoon(plat, {cdr}, 'support', 'None')
+            aiBrain:AssignUnitToPlatoon(plat, cdr, 'support', 'None')
             cdr.PlatoonHandle = plat
             cdr.PlatoonHandle.BuilderName = 'CDRRunAway'
             repeat
@@ -132,7 +132,7 @@ function CDROverCharge(aiBrain, cdr)
             cdr.UnitBeingBuiltBehavior = cdr.UnitBeingBuilt
         end
         local plat = aiBrain:MakePlatoon('', '')
-        aiBrain:AssignUnitsToPlatoon(plat, {cdr}, 'support', 'None')
+        aiBrain:AssignUnitToPlatoon(plat, cdr, 'support', 'None')
         cdr.PlatoonHandle = plat
         cdr.PlatoonHandle.BuilderName = 'CDROverCharge'
         plat:Stop()
@@ -260,7 +260,7 @@ function CDRReturnHome(aiBrain, cdr)
     local loc = cdr.CDRHome
     if not cdr.Initializing and not cdr.Dead and VDist2Sq(cdrPos[1], cdrPos[3], loc[1], loc[3]) > distSqAway then
         local plat = aiBrain:MakePlatoon('', '')
-        aiBrain:AssignUnitsToPlatoon(plat, {cdr}, 'support', 'None')
+        aiBrain:AssignUnitToPlatoon(plat, cdr, 'support', 'None')
         cdr.PlatoonHandle = plat
         cdr.PlatoonHandle.BuilderName = 'CDRReturnHome'
         repeat
@@ -334,7 +334,7 @@ function CommanderThread(cdr, platoon)
         and not cdr:IsUnitState("Upgrading") and not cdr:IsUnitState('BlockCommandQueue') then
             if not cdr.EngineerBuildQueue or table.empty(cdr.EngineerBuildQueue) then
                 local pool = aiBrain:GetPlatoonUniquelyNamed('ArmyPool')
-                aiBrain:AssignUnitsToPlatoon(pool, {cdr}, 'Unassigned', 'None')
+                aiBrain:AssignUnitToPlatoon(pool, cdr, 'Unassigned', 'None')
             elseif cdr.EngineerBuildQueue and not table.empty(cdr.EngineerBuildQueue) then
                 if not cdr.NotBuildingThread then
                     cdr.NotBuildingThread = cdr:ForkThread(platoon.WatchForNotBuilding)
@@ -385,7 +385,7 @@ function CommanderThreadImproved(cdr, platoon)
                 -- get the global armypool platoon
                 local pool = aiBrain:GetPlatoonUniquelyNamed('ArmyPool')
                 -- assing the CDR to the armypool
-                aiBrain:AssignUnitsToPlatoon(pool, {cdr}, 'Unassigned', 'None')
+                aiBrain:AssignUnitToPlatoon(pool, cdr, 'Unassigned', 'None')
             -- if we have a BuildQueue then continue building
             elseif cdr.EngineerBuildQueue and not table.empty(cdr.EngineerBuildQueue) then
                 if not cdr.NotBuildingThread then
@@ -450,7 +450,7 @@ function AirUnitRefitThread(unit, plan, data)
                     end
                     if closest then
                         local plat = aiBrain:MakePlatoon('', '')
-                        aiBrain:AssignUnitsToPlatoon(plat, {unit}, 'Attack', 'None')
+                        aiBrain:AssignUnitToPlatoon(plat, unit, 'Attack', 'None')
                         IssueStop({unit})
                         IssueToUnitClearCommands(unit)
                         IssueTransportLoad({unit}, closest)
@@ -502,7 +502,7 @@ function AirStagingThread(unit)
                         plat.PlatoonData = {}
                         plat.PlatoonData = v.PlatoonData
                     end
-                    aiBrain:AssignUnitsToPlatoon(plat, {v}, 'Attack', 'GrowthFormation')
+                    aiBrain:AssignUnitToPlatoon(plat, v, 'Attack', 'GrowthFormation')
                 end
             end
         end
@@ -971,7 +971,7 @@ function FatBoyBuildCheck(self)
     end
 
     if unitBeingBuilt and not unitBeingBuilt.Dead then
-        aiBrain:AssignUnitsToPlatoon(experimental.NewPlatoon, {unitBeingBuilt}, 'Attack', 'NoFormation')
+        aiBrain:AssignUnitToPlatoon(experimental.NewPlatoon, unitBeingBuilt, 'Attack', 'NoFormation')
         IssueToUnitClearCommands(unitBeingBuilt)
         IssueGuard({unitBeingBuilt}, experimental)
     end
@@ -1083,7 +1083,7 @@ TempestBehavior = function(self)
                 testHeading = unit:GetHeading()
                 unit.BuiltUnitCount = unit.BuiltUnitCount + 1
                 ScenarioFramework.CreateUnitDestroyedTrigger(TempestUnitDeath, unitBeingBuilt)
-                aiBrain:AssignUnitsToPlatoon(self, {unitBeingBuilt}, 'Attack', 'GrowthFormation')
+                aiBrain:AssignUnitToPlatoon(self, unitBeingBuilt, 'Attack', 'GrowthFormation')
                 IssueToUnitClearCommands(unitBeingBuilt)
                 unitBeingBuilt:ForkThread(TempestBuiltUnitMoveOut, position, testHeading)
             end

--- a/lua/AI/OpAI/BaseManagerPlatoonThreads.lua
+++ b/lua/AI/OpAI/BaseManagerPlatoonThreads.lua
@@ -43,7 +43,7 @@ function BaseManagerEngineerPlatoonSplit(platoon)
                 end
 
                 local engPlat = aiBrain:MakePlatoon('', '')
-                aiBrain:AssignUnitsToPlatoon(engPlat, {v}, 'Support', 'None')
+                aiBrain:AssignUnitToPlatoon(engPlat, v, 'Support', 'None')
                 engPlat:SetPlatoonData(platoon.PlatoonData)
                 v.BaseName = baseName
                 engPlat:ForkAIThread(BaseManagerSingleEngineerPlatoon)
@@ -476,7 +476,7 @@ function ConditionalBuildSuccessful(conditionalUnit)
 
     -- Assign AI
     local newPlatoon = aiBrain:MakePlatoon('', '')
-    aiBrain:AssignUnitsToPlatoon(newPlatoon, {conditionalUnit}, 'Attack', 'None')
+    aiBrain:AssignUnitToPlatoon(newPlatoon, conditionalUnit, 'Attack', 'None')
     newPlatoon:StopAI()
     newPlatoon:SetPlatoonData(selectedBuild.data.PlatoonData)
 
@@ -1279,7 +1279,7 @@ function BaseManagerTMLPlatoon(platoon)
 	for _, launcher in TMLs do
 		if not launcher.Dead then
 			local launcherPlatoon = aiBrain:MakePlatoon('', '')
-            aiBrain:AssignUnitsToPlatoon(launcherPlatoon, {launcher}, 'Attack', 'None')
+            aiBrain:AssignUnitToPlatoon(launcherPlatoon, launcher, 'Attack', 'None')
             launcherPlatoon.PlatoonData = table.deepcopy(platoon.PlatoonData)
             launcherPlatoon:ForkAIThread(BaseManagerTMLAI)
 		end
@@ -1362,7 +1362,7 @@ function BaseManagerNukePlatoon(platoon)
 	for _, silo in SMLs do
 		if not silo.Dead then
 			local siloPlatoon = aiBrain:MakePlatoon('', '')
-            aiBrain:AssignUnitsToPlatoon(siloPlatoon, {silo}, 'Support', 'None')
+            aiBrain:AssignUnitToPlatoon(siloPlatoon, silo, 'Support', 'None')
             siloPlatoon.PlatoonData = table.deepcopy(platoon.PlatoonData)
             siloPlatoon:ForkAIThread(BaseManagerNukeAI)
 		end
@@ -1528,7 +1528,7 @@ function UnitUpgradeThread(unit)
                 end
 
                 local platoon = aiBrain:MakePlatoon('', '')
-                aiBrain:AssignUnitsToPlatoon(platoon, {unit}, 'support', 'none')
+                aiBrain:AssignUnitToPlatoon(platoon, unit, 'support', 'none')
 
                 local order = {
                     TaskName = "EnhanceTask",

--- a/lua/AI/OpAI/OpBehaviors.lua
+++ b/lua/AI/OpAI/OpBehaviors.lua
@@ -58,7 +58,7 @@ function CDROverChargeThread( cdr )
                     cdr.UnitBeingBuiltBehavior = cdr:GetUnitBeingBuilt()
                 end
                 plat = aiBrain:MakePlatoon( '', '' )
-                aiBrain:AssignUnitsToPlatoon( plat, {cdr}, 'support', 'None' )
+                aiBrain:AssignUnitToPlatoon( plat, cdr, 'support', 'None' )
                 plat:Stop()
                 local priList = { categories.COMMAND, categories.EXPERIMENTAL, categories.TECH3 * categories.INDIRECTFIRE,
                     categories.TECH3 * categories.MOBILE, categories.TECH2 * categories.INDIRECTFIRE, categories.MOBILE * categories.TECH2,
@@ -150,7 +150,7 @@ function CDRRepairBuildingUnit( cdr, plat )
     end
     if not cdr:IsDead() and not ( cdr.Fighting or cdr.Running or cdr.GivingUp or cdr.Leashing or cdr.Cornered ) then
         local pool = aiBrain:GetPlatoonUniquelyNamed('ArmyPool')
-        aiBrain:AssignUnitsToPlatoon( pool, {cdr}, 'Unassigned', 'None' )
+        aiBrain:AssignUnitToPlatoon( pool, cdr, 'Unassigned', 'None' )
     end
 end
 
@@ -178,7 +178,7 @@ function CDRLeashThread(cdr)
             local cdrPos = cdr:GetPosition()
             if VDist2( cdrPos[1], cdrPos[3], loc[1], loc[3] ) > rad then
                 local plat = aiBrain:MakePlatoon( '', '' )
-                aiBrain:AssignUnitsToPlatoon( plat, {cdr}, 'support', 'none' )
+                aiBrain:AssignUnitToPlatoon( plat, cdr, 'support', 'none' )
                 plat:Stop()
                 plat:MoveToLocation( loc, false )
                 cdr.Leashing = true
@@ -220,7 +220,7 @@ function CDRRunAwayThread( cdr )
                 end
                 cdr.Running = true
                 local plat = aiBrain:MakePlatoon( '', '' )
-                aiBrain:AssignUnitsToPlatoon( plat, {cdr}, 'support', 'None' )
+                aiBrain:AssignUnitToPlatoon( plat, cdr, 'support', 'None' )
                 repeat
                     plat:Stop()
                     cmd = plat:MoveToLocation( runSpot, false )

--- a/lua/AI/Transportutilities.lua
+++ b/lua/AI/Transportutilities.lua
@@ -27,7 +27,6 @@ local VDist2 = VDist2
 local VDist3 = VDist3
 local WaitTicks = coroutine.yield
 
-local AssignUnitsToPlatoon = moho.aibrain_methods.AssignUnitsToPlatoon
 local GetFuelRatio = moho.unit_methods.GetFuelRatio
 local GetFractionComplete = moho.entity_methods.GetFractionComplete
 local GetListOfUnits = moho.aibrain_methods.GetListOfUnits
@@ -94,7 +93,7 @@ function AssignTransportToPool( unit, aiBrain )
 		-- if not in need of repair or fuel -- 
 		if not ProcessAirUnits( unit, aiBrain ) then
             if aiBrain.TransportPool then
-                AssignUnitsToPlatoon( aiBrain, aiBrain.TransportPool, {unit}, 'Support','')
+                aiBrain:AssignUnitToPlatoon( aiBrain.TransportPool, unit, 'Support','')
             else
                 return
             end
@@ -327,7 +326,7 @@ function GetTransports( platoon, aiBrain)
 
                         -- this puts specials into the transport pool -- occurs to me that they
                         -- may get stuck in here if it turns out we cant use transports
-                        AssignUnitsToPlatoon( aiBrain, transportpool, {trans}, 'Support','none')
+                        aiBrain:AssignUnitToPlatoon( aiBrain.TransportPool, trans, 'Support','none')
                     
                         -- limit collection of armypool transports to 15
                         if transportcount == 15 then
@@ -666,7 +665,7 @@ function GetTransports( platoon, aiBrain)
                     LOG("*AI DEBUG "..aiBrain.Nickname.." "..platoon.BuilderName.." "..transportplatoon.BuilderName.." adds transport "..transport.EntityId)
                 end
                 
-				AssignUnitsToPlatoon( aiBrain, transportplatoon, {transport}, 'Support', 'BlockFormation')
+				aiBrain:AssignUnitToPlatoon( transportplatoon, transport, 'Support', 'BlockFormation')
 				IssueToUnitClearCommands(transport)
 				IssueToUnitMove(transport, location )
 
@@ -831,7 +830,7 @@ function ReturnTransportsToPool( aiBrain, units, move )
                 returnpool = aiBrain:MakePlatoon('TransportRTB'..tostring(v.EntityId), 'none')
                 returnpool.BuilderName = 'TransportRTB'..tostring(v.EntityId)
                 returnpool.PlanName = returnpool.BuilderName
-                AssignUnitsToPlatoon( aiBrain, returnpool, {v}, 'Unassigned', '')
+                aiBrain:AssignUnitToPlatoon( returnpool, v, 'Unassigned', '')
                 if TransportDialog then
                     LOG("*AI DEBUG "..aiBrain.Nickname.." "..returnpool.BuilderName.." Transport "..v.EntityId.." assigned" )
                 end
@@ -877,7 +876,7 @@ function ReturnTransportsToPool( aiBrain, units, move )
                             if TransportDialog then
                                 LOG("*AI DEBUG "..aiBrain.Nickname.." "..v.PlatoonHandle.BuilderName.." transport "..v.EntityId.." now in the Transport Pool  InUse is "..repr(v.InUse))
                             end
-                            AssignUnitsToPlatoon( aiBrain, aiBrain.TransportPool, {v}, 'Support', '' )
+                            aiBrain:AssignUnitToPlatoon( aiBrain.TransportPool, v, 'Support', '' )
                             v.PlatoonHandle = aiBrain.TransportPool
                             v.InUse = false
                             v.Assigning = false                            
@@ -886,7 +885,7 @@ function ReturnTransportsToPool( aiBrain, units, move )
                         if TransportDialog then
                             LOG("*AI DEBUG "..aiBrain.Nickname.." "..v.PlatoonHandle.BuilderName.." assigned unit "..v.EntityId.." "..v:GetBlueprint().Description.." to the Army Pool" )
                         end
-						AssignUnitsToPlatoon( aiBrain, aiBrain.ArmyPool, {v}, 'Unassigned', '' )
+						aiBrain:AssignUnitToPlatoon( aiBrain.ArmyPool, v, 'Unassigned', '' )
 						v.PlatoonHandle = aiBrain.ArmyPool
        					v.InUse = false
                         v.Assigning = false
@@ -910,7 +909,7 @@ function ReturnUnloadedUnitToPool( aiBrain, unit )
 		IssueToUnitClearCommands(unit)
 		local ident = Random(1,999999)
 		local returnpool = aiBrain:MakePlatoon('ReturnToPool'..tostring(ident), 'none')
-		AssignUnitsToPlatoon( aiBrain, returnpool, {unit}, 'Unassigned', 'None' )
+		aiBrain:AssignUnitToPlatoon( returnpool, unit, 'Unassigned', 'None' )
 		returnpool.PlanName = 'ReturnToBaseAI'
 		returnpool.BuilderName = 'FailedUnload'
 		while attached and not unit.Dead do
@@ -1466,7 +1465,7 @@ function UseTransports( aiBrain, transports, location, UnitPlatoon, IsEngineer )
 			end
 			local ident = Random(1,999999)
 			local returnpool = aiBrain:MakePlatoon('RTB - Excess in SortingOnTransport'..tostring(ident), 'none')
-			AssignUnitsToPlatoon( aiBrain, returnpool, currLeftovers, 'Unassigned', 'None' )
+			aiBrain:AssignUnitsToPlatoon( aiBrain, returnpool, currLeftovers, 'Unassigned', 'None' )
 			returnpool.PlanName = 'ReturnToBaseAI'
 			returnpool.BuilderName = 'SortUnitsOnTransportsLeftovers'..tostring(ident)
 			returnpool:SetAIPlan('ReturnToBaseAI',aiBrain)
@@ -1594,7 +1593,7 @@ function UseTransports( aiBrain, transports, location, UnitPlatoon, IsEngineer )
 						end
 					end
 					IssueToUnitClearCommands(v)
-					AssignUnitsToPlatoon( aiBrain, returnpool, {v}, 'Attack', 'None' )
+					aiBrain:AssignUnitToPlatoon( returnpool, v, 'Attack', 'None' )
 				end
 			end
 		end
@@ -2165,7 +2164,7 @@ function TransportReturnToBase(unit, aiBrain)
 
 	local returnpool = aiBrain:MakePlatoon('AirRefit'..tostring(ident), 'none')
 	if not unit.Dead then
-		AssignUnitsToPlatoon( aiBrain, returnpool, {unit}, 'Unassigned', '')
+		aiBrain:AssignUnitToPlatoon( returnpool, unit, 'Unassigned', '')
 		unit.PlatoonHandle = returnpool
 	end
 	while (not unit.Dead) do

--- a/lua/AI/aiattackutilities.lua
+++ b/lua/AI/aiattackutilities.lua
@@ -766,7 +766,7 @@ function SendPlatoonWithTransports(aiBrain, platoon, destination, bRequired, bSk
                         local pool = aiBrain:GetPlatoonUniquelyNamed('ArmyPool')
                         for _,v in overflow do
                             if not v.Dead then
-                                aiBrain:AssignUnitsToPlatoon(pool, {v}, 'Unassigned', 'None')
+                                aiBrain:AssignUnitToPlatoon(pool, v, 'Unassigned', 'None')
                             end
                         end
                         units = goodunits
@@ -943,7 +943,7 @@ function SendPlatoonWithTransportsNoCheck(aiBrain, platoon, destination, bRequir
                         local pool = aiBrain:GetPlatoonUniquelyNamed('ArmyPool')
                         for _,v in overflow do
                             if not v.Dead then
-                                aiBrain:AssignUnitsToPlatoon(pool, {v}, 'Unassigned', 'None')
+                                aiBrain:AssignUnitToPlatoon(pool, v, 'Unassigned', 'None')
                             end
                         end
                         units = goodunits

--- a/lua/AI/aibuildstructures.lua
+++ b/lua/AI/aibuildstructures.lua
@@ -305,7 +305,7 @@ function DoHackyLogic(buildingType, builder)
                 if unitInstance then
                     TriggerFile.CreateUnitStopBeingBuiltTrigger(function(unitBeingBuilt)
                         local newPlatoon = aiBrain:MakePlatoon('', '')
-                        aiBrain:AssignUnitsToPlatoon(newPlatoon, {unitBeingBuilt}, 'Attack', 'None')
+                        aiBrain:AssignUnitToPlatoon(newPlatoon, unitBeingBuilt, 'Attack', 'None')
                         newPlatoon:StopAI()
                         newPlatoon:ForkAIThread(newPlatoon.TacticalAI)
                     end, unitInstance)

--- a/lua/AI/aiutilities.lua
+++ b/lua/AI/aiutilities.lua
@@ -1193,7 +1193,7 @@ function AIEngineersAssistFactories(aiBrain, engineers, factories)
             IssueGuard({unit}, factoryData[key].Factory)
             factoryData[key].NumGuards = factoryData[key].NumGuards + 1
         else
-            aiBrain:AssignUnitsToPlatoon('ArmyPool', {unit}, 'Unassigned', 'NoFormation')
+            aiBrain:AssignUnitToPlatoon('ArmyPool', unit, 'Unassigned', 'NoFormation')
         end
     end
 
@@ -1702,7 +1702,7 @@ function GetTransports(platoon, units)
         for i = 1, table.getn(sortedList) do
             if transportsNeeded and table.empty(sortedList[i].Unit:GetCargo()) and not sortedList[i].Unit:IsUnitState('TransportLoading') then
                 local id = sortedList[i].Id
-                aiBrain:AssignUnitsToPlatoon(platoon, {sortedList[i].Unit}, 'Scout', 'GrowthFormation')
+                aiBrain:AssignUnitToPlatoon(platoon, sortedList[i].Unit, 'Scout', 'GrowthFormation')
                 numTransports = numTransports + 1
                 if not transSlotTable[id] then
                     transSlotTable[id] = GetNumTransportSlots(sortedList[i].Unit)
@@ -1796,7 +1796,7 @@ function UseTransports(units, transports, location, transportPlatoon)
     for num, unit in units do
         if not unit.Dead then
             if unit:IsUnitState('Attached') then
-                aiBrain:AssignUnitsToPlatoon(pool, {unit}, 'Unassigned', 'None')
+                aiBrain:AssignUnitToPlatoon(pool, unit, 'Unassigned', 'None')
             elseif EntityCategoryContains(categories.url0306 + categories.DEFENSE, unit) then
                 table.insert(shields, unit)
             elseif unit:GetBlueprint().Transport.TransportClass == 3 then
@@ -1880,7 +1880,7 @@ function UseTransports(units, transports, location, transportPlatoon)
     for k, unit in units do
         if not unit.Dead and not EntityCategoryContains(categories.TRANSPORTATION, unit) then
             if not unit:IsUnitState('Attached') then
-                aiBrain:AssignUnitsToPlatoon(pool, {unit}, 'Unassigned', 'None')
+                aiBrain:AssignUnitToPlatoon(pool, unit, 'Unassigned', 'None')
             end
         elseif not unit.Dead and EntityCategoryContains(categories.TRANSPORTATION, unit) and table.empty(unit:GetCargo()) then
             ReturnTransportsToPool({unit}, true)
@@ -1891,7 +1891,7 @@ function UseTransports(units, transports, location, transportPlatoon)
     -- If some transports have no units return to pool
     for k, t in transports do
         if not t.Dead and table.empty(t:GetCargo()) then
-            aiBrain:AssignUnitsToPlatoon('ArmyPool', {t}, 'Scout', 'None')
+            aiBrain:AssignUnitToPlatoon('ArmyPool', t, 'Scout', 'None')
             table.remove(transports, k)
         end
     end
@@ -2043,7 +2043,7 @@ function ReturnTransportsToPool(units, move)
     local safePath, reason = AIAttackUtils.PlatoonGenerateSafePathTo(aiBrain, 'Air', unit:GetPosition(), position, 200)
     for k, unit in units do
         if not unit.Dead and EntityCategoryContains(categories.TRANSPORTATION, unit) then
-            aiBrain:AssignUnitsToPlatoon('ArmyPool', {unit}, 'Scout', 'None')
+            aiBrain:AssignUnitToPlatoon('ArmyPool', unit, 'Scout', 'None')
             if move then
                 if safePath then
                     for _, p in safePath do
@@ -2969,7 +2969,7 @@ function UseTransportsGhetto(units, transports)
     for num, unit in units do
         if not unit.Dead then
             if unit:IsUnitState('Attached') then
-                aiBrain:AssignUnitsToPlatoon(pool, {unit}, 'Unassigned', 'None')
+                aiBrain:AssignUnitToPlatoon(pool, unit, 'Unassigned', 'None')
             elseif EntityCategoryContains(categories.url0306 + categories.DEFENSE, unit) then
                 table.insert(shields, unit)
             elseif unit:GetBlueprint().Transport.TransportClass == 3 then
@@ -3054,7 +3054,7 @@ function UseTransportsGhetto(units, transports)
     for k, unit in units do
         if not unit.Dead and not EntityCategoryContains(categories.TRANSPORTATION, unit) then
             if not unit:IsUnitState('Attached') then
-                aiBrain:AssignUnitsToPlatoon(pool, {unit}, 'Unassigned', 'None')
+                aiBrain:AssignUnitToPlatoon(pool, unit, 'Unassigned', 'None')
             end
         elseif not unit.Dead and EntityCategoryContains(categories.TRANSPORTATION, unit) and table.empty(unit:GetCargo()) then
             ReturnTransportsToPool({unit}, true)

--- a/lua/ScenarioPlatoonAI.lua
+++ b/lua/ScenarioPlatoonAI.lua
@@ -648,7 +648,7 @@ function EngineersBuildPlatoon(platoon)
                         end
                        )
                     end
-                    aiBrain:AssignUnitsToPlatoon(aiBrain.EngBuiltPlatoonList[buildingPlatoon], {unitBeingBuilt}, 'Attack', 'NoFormation')
+                    aiBrain:AssignUnitToPlatoon(aiBrain.EngBuiltPlatoonList[buildingPlatoon], unitBeingBuilt, 'Attack', 'NoFormation')
                 end
             end
             buildingPlatoon = false
@@ -1018,9 +1018,7 @@ function ReturnTransportsToPool(platoon, data)
         return
     end
 
-    for _, unit in transports do
-        aiBrain:AssignUnitsToPlatoon(tPool, {unit}, 'Scout', 'None')
-    end
+    aiBrain:AssignUnitsToPlatoon(tPool, transports, 'Scout', 'None')
 
     -- If a route or chain was given, reverse it on return
     if data.TransportRoute then
@@ -1869,7 +1867,7 @@ function GetLoadTransports(platoon)
     for _, unit in unitsToDrop do
         if not unit.Dead and not unit:IsUnitState('Attached') then
             unit:Kill()
-            -- aiBrain:AssignUnitsToPlatoon(pool, {unit}, 'Unassigned', 'None')
+            -- aiBrain:AssignUnitToPlatoon(pool, unit, 'Unassigned', 'None')
         end
     end
 
@@ -2228,7 +2226,7 @@ function GetTransportsThread(platoon)
                     for i = 1, table.getn(sortedList) do
                         if transportsNeeded then
                             local id = sortedList[i].Id
-                            aiBrain:AssignUnitsToPlatoon(platoon, {sortedList[i].Unit}, 'Scout', 'GrowthFormation')
+                            aiBrain:AssignUnitToPlatoon(platoon, sortedList[i].Unit, 'Scout', 'GrowthFormation')
                             numTransports = numTransports + 1
                             if not transSlotTable[id] then
                                 transSlotTable[id] = GetNumTransportSlots(sortedList[i].Unit)

--- a/lua/aibrain.lua
+++ b/lua/aibrain.lua
@@ -48,6 +48,9 @@ local AIChatBrainComponent = import("/lua/aibrains/components/ChatBrainComponent
 local BrainGetUnitsAroundPoint = moho.aibrain_methods.GetUnitsAroundPoint
 local BrainGetListOfUnits = moho.aibrain_methods.GetListOfUnits
 local CategoriesDummyUnit = categories.DUMMYUNIT
+--- Cached table for assigning a single unit to a platoon, to avoid creating a new table every time.
+---@type { [1]: Unit }
+local cachedPlatoonUnit = {}
 
 ---@class AIBrain: FactoryManagerBrainComponent, StatManagerBrainComponent, JammerManagerBrainComponent, EnergyManagerBrainComponent, StorageManagerBrainComponent, AIChatBrainComponent, moho.aibrain_methods
 ---@field AI boolean
@@ -644,6 +647,18 @@ AIBrain = Class(FactoryManagerBrainComponent, StatManagerBrainComponent, JammerM
 
         -- retrieve units, excluding insignificant units
         return BrainGetListOfUnits(self, cats - CategoriesDummyUnit, needToBeIdle, requireBuilt)
+    end,
+
+    --- Assigns a single unit to a platoon
+    ---@param self AIBrain
+    ---@param platoon Platoon | string Either a reference to a platoon, or the unique name of the platoon
+    ---@param unit Unit
+    ---@param squad PlatoonSquads
+    ---@param formation UnitFormations
+    ---@return UnitFormations #Returns the name of the formation
+    AssignUnitToPlatoon = function(self, platoon, unit, squad, formation)
+        cachedPlatoonUnit[1] = unit
+        return self:AssignUnitsToPlatoon(platoon, cachedPlatoonUnit, squad, formation)
     end,
 
     --#endregion

--- a/lua/aibrains/easy-ai.lua
+++ b/lua/aibrains/easy-ai.lua
@@ -306,7 +306,7 @@ AIBrain = Class(StandardBrain, EconomyComponent) {
             platoon.Base = nearestBase
             platoon.Brain = self
             setmetatable(platoon, import("/lua/aibrains/platoons/platoon-simple-engineer.lua").AIPlatoonEngineerSimple)
-            self:AssignUnitsToPlatoon(platoon, { unit }, 'Support', 'GrowthFormation')
+            self:AssignUnitToPlatoon(platoon, unit , 'Support', 'GrowthFormation')
             ChangeState(platoon, platoon.Start)
         end
 

--- a/lua/aibrains/managers/factory-manager.lua
+++ b/lua/aibrains/managers/factory-manager.lua
@@ -387,7 +387,7 @@ AIFactoryManager = ClassSimple {
             setmetatable(platoon, self:GetFactoryPlatoonMetaTable())
             platoon.Base = self.Base
             platoon.Brain = self.Brain
-            self.Brain:AssignUnitsToPlatoon(platoon, { unit }, 'Unassigned', 'None')
+            self.Brain:AssignUnitToPlatoon(platoon, unit, 'Unassigned', 'None')
             ChangeState(platoon, platoon.Start)
         end
     end,

--- a/lua/aibrains/managers/structure-manager.lua
+++ b/lua/aibrains/managers/structure-manager.lua
@@ -255,7 +255,7 @@ AIStructureManager = ClassSimple {
             -- platoon.Base = self.Base
 
             -- setmetatable(platoon, import("/lua/aibrains/platoons/platoon-simple-structure.lua").AIPlatoonSimpleStructure)
-            -- brain:AssignUnitsToPlatoon(platoon, { unit }, 'Unassigned', 'None')
+            -- brain:AssignUnitToPlatoon(platoon, unit, 'Unassigned', 'None')
             -- ChangeState(platoon, platoon.Start)
         end
     end,

--- a/lua/aibrains/platoons/platoon-adaptive-engineer-task.lua
+++ b/lua/aibrains/platoons/platoon-adaptive-engineer-task.lua
@@ -82,7 +82,7 @@ AIPlatoonEngineerBehavior = Class(AIPlatoon) {
                 self:LogDebug(string.format('PreAllocatedTask detected, task is '..tostring(data.Task)))
                 if data.Task == 'Reclaim' then
                     local plat = aiBrain:MakePlatoon('', '')
-                    aiBrain:AssignUnitsToPlatoon(plat, {unit}, 'support', 'None')
+                    aiBrain:AssignUnitToPlatoon(plat, unit, 'support', 'None')
                     import("/lua/aibrains/platoons/platoon-adaptive-reclaim.lua").AssignToUnitsMachine({ }, self, self:GetPlatoonUnits())
                     return
                 elseif data.Task == 'ReclaimStructure' then

--- a/lua/sim/EngineerManager.lua
+++ b/lua/sim/EngineerManager.lua
@@ -771,7 +771,7 @@ EngineerManager = Class(BuilderManager) {
             -- Fork off the platoon here
             local template = self:GetEngineerPlatoonTemplate(builder:GetPlatoonTemplate())
             local hndl = self.Brain:MakePlatoon(template[1], template[2])
-            self.Brain:AssignUnitsToPlatoon(hndl, {unit}, 'support', 'none')
+            self.Brain:AssignUnitToPlatoon(hndl, unit, 'support', 'none')
             unit.PlatoonHandle = hndl
 
             --if EntityCategoryContains(categories.COMMAND, unit) then

--- a/lua/sim/ScenarioUtilities.lua
+++ b/lua/sim/ScenarioUtilities.lua
@@ -264,7 +264,7 @@ function CreateArmyUnit(strArmy, strUnit)
         while i <= table.getn(Scenario.Platoons[tblUnit.platoon]) do
             if tblUnit.Type == currTemplate[i][1] then
                 platoon = brain:MakePlatoon('None', 'None')
-                brain:AssignUnitsToPlatoon(platoon, { unit }, currTemplate[i][4], currTemplate[i][5])
+                brain:AssignUnitToPlatoon(platoon, unit, currTemplate[i][4], currTemplate[i][5])
                 break
             end
             i = i + 1
@@ -985,7 +985,7 @@ function CreatePlatoons(strArmy, tblNode, tblResult, platoonList, currPlatoon, t
                     if tblData.type == currTemplate[i][1] and
                         platoonList[currPlatoon].squadCounter[i] < currTemplate[i][3] then
                         platoonList[currPlatoon].squadCounter[i] = platoonList[currPlatoon].squadCounter[i] + 1
-                        brain:AssignUnitsToPlatoon(platoonList[currPlatoon], { unit }, currTemplate[i][4],
+                        brain:AssignUnitToPlatoon(platoonList[currPlatoon], unit, currTemplate[i][4],
                             currTemplate[i][5])
                         inserted = true
                     end
@@ -1130,7 +1130,7 @@ function CreateArmyGroupAsPlatoon(strArmy, strGroup, formation, tblNode, platoon
                 ScenarioInfo.UnitNames[armyIndex][strName] = unit
             end
             unit.UnitName = strName
-            brain:AssignUnitsToPlatoon(platoon, { unit }, 'Attack', formation)
+            brain:AssignUnitToPlatoon(platoon, unit, 'Attack', formation)
 
             if balance then
                 ScenarioInfo.LoadBalance.Accumulator = ScenarioInfo.LoadBalance.Accumulator + 1


### PR DESCRIPTION
## Description of the proposed changes
- Adds `aibrain:AssignUnitToPlatoon()` function for a single unit, the table passed to `AssignUnitsToPlatoon` is cached and just the single unit swapped, just like `IssueToUnit` commads work.

## Testing done on the proposed changes
- played couple of coop missions

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for assigning individual units directly to platoons.
  - Updated AI, transport, engineer, factory, and scenario systems to use streamlined single-unit assignments.
  - Retained support for assigning multiple units together when appropriate.

- **Bug Fixes**
  - Improved consistency and reliability when assigning engineers, commanders, factories, transports, and other units to platoons.
  - Reduced unnecessary handling when placing individual units into platoons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->