### PR TITLE
Always clear build templates when ending command mode

### DIFF
--- a/changelog/snippets/fix.7261.md
+++ b/changelog/snippets/fix.7261.md
@@ -1,1 +1,1 @@
-- Your explanation here... [Don't forget to change the category in the filename] (#7261).
+- Always clear build templates when ending command mode (#7261). This fixes build templates that were canceled by right click appearing when cheating in units.

--- a/changelog/snippets/fix.7261.md
+++ b/changelog/snippets/fix.7261.md
@@ -1,0 +1,1 @@
+- Your explanation here... [Don't forget to change the category in the filename] (#7261).

--- a/lua/keymap/hotbuild.lua
+++ b/lua/keymap/hotbuild.lua
@@ -147,7 +147,6 @@ function resetCycle(commandMode, modeData)
     -- Commandmode = false is when a building is built (left click with mouse)
     -- modeData.isCancel = false is when building is aborted by a right click... whyever
     -- modeData.isCancel = true when "canceling" by releasing shift
-    LOG('hotbuild reset cycle', commandMode, repr(modeData))
     if commandMode == false or (not modeData) or not (modeData.isCancel) then
         -- Set to 0, first one is 1 but it will be incremented!
         cyclePos = 0

--- a/lua/keymap/hotbuild.lua
+++ b/lua/keymap/hotbuild.lua
@@ -340,7 +340,7 @@ function StopCycleMap(self, event)
         local fadeTime = options.hotbuild_cycle_reset_time / 2000.0
         Effect.FadeOut(cycleMap, fadeTime, 0.6, 0.1)
     end)
-    CommandMode.EndCommandMode()
+    CommandMode.EndCommandMode(false)
 end
 
 function hideCycleMap()

--- a/lua/keymap/hotbuild.lua
+++ b/lua/keymap/hotbuild.lua
@@ -147,6 +147,7 @@ function resetCycle(commandMode, modeData)
     -- Commandmode = false is when a building is built (left click with mouse)
     -- modeData.isCancel = false is when building is aborted by a right click... whyever
     -- modeData.isCancel = true when "canceling" by releasing shift
+    LOG('hotbuild reset cycle', commandMode, repr(modeData))
     if commandMode == false or (not modeData) or not (modeData.isCancel) then
         -- Set to 0, first one is 1 but it will be incremented!
         cyclePos = 0

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -177,7 +177,6 @@ end
 ---@param newCommandMode CommandMode
 ---@param data CommandModeData
 function StartCommandMode(newCommandMode, data)
-    LOG('StartCommandMode', newCommandMode, repr(data), debug.traceback())
     -- clean up previous command mode
     if commandMode then
         EndCommandMode(true)

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -212,11 +212,7 @@ function EndCommandMode(isCancel)
         -- add information to modeData for end behavior
         modeData.isCancel = isCancel or false
 
-        -- ???
-        LOG('end command mode iscancel', isCancel, 'modedata', repr(modeData), '\n'..debug.traceback())
-        if modeData.isCancel then
-            ClearBuildTemplates()
-        end
+        ClearBuildTemplates()
 
         -- regain selection if we were cheating in units
         if modeData.cheat and modeData.selection then

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -194,8 +194,15 @@ function StartCommandMode(newCommandMode, data)
 end
 
 --- Called when the command mode ends and deconstructs all the data.
----@param isCancel boolean # set when we're at the end of (a sequence of) order(s), is usually always true. False when the mode is ended with right click, except for "ping" mode.
+---@param isCancel boolean # set when we're at the end of (a sequence of) order(s), is usually always true.
 function EndCommandMode(isCancel)
+    -- isCancel = false when:
+    -- - the mode is ended with right click, except for "ping" mode.
+    -- - new mode with same name is started by console command
+    -- - when the selection changes
+    -- - unit is removed from extra select list
+    -- - lua calls it with false
+
     if ignoreSelection then
         return
     end

--- a/lua/ui/game/commandmode.lua
+++ b/lua/ui/game/commandmode.lua
@@ -177,6 +177,7 @@ end
 ---@param newCommandMode CommandMode
 ---@param data CommandModeData
 function StartCommandMode(newCommandMode, data)
+    LOG('StartCommandMode', newCommandMode, repr(data), debug.traceback())
     -- clean up previous command mode
     if commandMode then
         EndCommandMode(true)
@@ -205,6 +206,7 @@ function EndCommandMode(isCancel)
         modeData.isCancel = isCancel or false
 
         -- ???
+        LOG('end command mode iscancel', isCancel, 'modedata', repr(modeData), '\n'..debug.traceback())
         if modeData.isCancel then
             ClearBuildTemplates()
         end


### PR DESCRIPTION
## Description of the proposed changes
Fixes ending template build with right click carrying over the template into cheat spawn's visuals.

## Testing done on the proposed changes
Start template build mode. Cancel with right click. Start cheat spawn mode. It should not show the template that you canceled.

## Additional context
I looked in the engine and documented every instance of the command mode ending with `isCancel = false`. I couldn't understand why templates weren't cleared if it was a right click order. It doesn't make sense to me because it ends the command mode regardless, which loses the build mode capability that is required for templates to work, and if you want to re-enable the build mode capability, then you should re-enable it with a template if you want a template, not have some remainder template carrying over because you pressed right click.


## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Build templates are now consistently cleared when command mode ends.
  - Prevented canceled build templates from appearing during unit cheating.
  - Improved cleanup when leaving command mode, including when a command is stopped normally or canceled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->