### PR TITLE
Annotate WldUiProvider class

### DIFF
--- a/changelog/snippets/category.7268.md
+++ b/changelog/snippets/category.7268.md
@@ -1,1 +1,0 @@
-- Your explanation here... [Don't forget to change the category in the filename] (#7268).

--- a/changelog/snippets/category.7268.md
+++ b/changelog/snippets/category.7268.md
@@ -1,0 +1,1 @@
+- Your explanation here... [Don't forget to change the category in the filename] (#7268).

--- a/changelog/snippets/other.7268.md
+++ b/changelog/snippets/other.7268.md
@@ -1,0 +1,1 @@
+- Annotate `WldUiProvider` class (#7268).

--- a/engine/User/CLuaWldUIProvider.lua
+++ b/engine/User/CLuaWldUIProvider.lua
@@ -7,4 +7,44 @@ local CLuaWldUIProvider = {}
 function CLuaWldUIProvider:Destroy()
 end
 
+--- Called by the engine when the world starts loading.
+---@type fun(self: moho.WldUIProvider_methods)
+CLuaWldUIProvider.StartLoadingDialog = nil
+
+--- Engine never calls this, but the method exists.
+---@type fun(self: moho.WldUIProvider_methods, elapsedTime: number)
+CLuaWldUIProvider.UpdateLoadingDialog = nil
+
+--- Called by the engine when the world finishes loading.
+---@type fun(self: moho.WldUIProvider_methods)
+CLuaWldUIProvider.StopLoadingDialog = nil
+
+--- Called by the engine after `StopLoadingDialog`.
+---@type fun(self: moho.WldUIProvider_methods): string[]?
+CLuaWldUIProvider.GetPrefetchTextures = nil
+
+--- Called by the engine after prefetching textures.
+---@type fun(self: moho.WldUIProvider_methods, isReplay: boolean)
+CLuaWldUIProvider.CreateGameInterface = nil
+
+--- Called by the engine when the world is loaded locally but online clients aren't ready.
+---@type fun(self: moho.WldUIProvider_methods)
+CLuaWldUIProvider.StartWaitingDialog = nil
+
+--- Engine never calls this, but the method exists.
+---@type fun(self: moho.WldUIProvider_methods, elapsedTime: number)
+CLuaWldUIProvider.UpdateWaitingDialog = nil
+
+--- Called by the engine when all online clients become ready.
+---@type fun(self: moho.WldUIProvider_methods)
+CLuaWldUIProvider.StopWaitingDialog = nil
+
+--- Called by the engine after everyone is connected and world starts playing.
+---@type fun(self: moho.WldUIProvider_methods)
+CLuaWldUIProvider.OnStart = nil
+
+--- Called by the engine when ending the game session or closing the app.
+---@type fun(self: moho.WldUIProvider_methods)
+CLuaWldUIProvider.DestroyGameInterface = nil
+
 return CLuaWldUIProvider

--- a/lua/maui/movie.lua
+++ b/lua/maui/movie.lua
@@ -9,6 +9,7 @@
 local Control = import("/lua/maui/control.lua").Control
 
 ---@class Movie : moho.movie_methods, Control, InternalObject
+---@overload fun(parent: Control, filename?: FileName, sound?: SoundHandle, voice?: SoundHandle): Movie
 Movie = ClassUI(moho.movie_methods, Control) {
 
     __init = function(self, parent, filename, sound, voice)

--- a/lua/ui/game/gamemain.lua
+++ b/lua/ui/game/gamemain.lua
@@ -387,8 +387,10 @@ function AdjustFrameRate()
     ConExecute("SC_FrameTimeClamp " .. (1000 / fps))
 end
 
+---@type WldUIProvider | false
 local provider = false
 
+---@return Movie
 local function LoadDialog(parent)
     local movieFile = '/movies/UEF_load.sfd'
     local color = 'FFbadbdb'
@@ -442,10 +444,7 @@ function CreateWldUIProvider()
 
     provider = WldUIProvider()
 
-    local loadingDialog = false
-    local frame1Logo = false
-
-    local lastTime = 0
+    local loadingDialog = false ---@type Movie | false
 
     provider.StartLoadingDialog = function(self)
         GetCursor():Hide()
@@ -536,10 +535,6 @@ function CreateWldUIProvider()
 
     provider.CreateGameInterface = function(self, inIsReplay)
         isReplay = inIsReplay
-        if frame1Logo then
-            frame1Logo:Destroy()
-            frame1Logo = false
-        end
         CreateUI(isReplay)
         if not import("/lua/ui/campaign/campaignmanager.lua").campaignMode then
             HideGameUI('on')

--- a/lua/ui/game/wlduiprovider.lua
+++ b/lua/ui/game/wlduiprovider.lua
@@ -6,40 +6,60 @@
 --* Copyright © 2005 Gas Powered Games, Inc.  All rights reserved.
 --*****************************************************************************
 
--- Functions exposed to lua
-
+--- Responds to Wld UI Events to show appropriate UI
 ---@class WldUIProvider : moho.WldUIProvider_methods
+---@overload fun(): WldUIProvider
 WldUIProvider = ClassUI(moho.WldUIProvider_methods) {
     __init = function(self)
         InternalCreateWldUIProvider(self)
     end,
 
+    --- Called by the engine when the world starts loading.
+    ---@param self WldUIProvider
     StartLoadingDialog = function(self)
     end,
 
+    --- Engine never calls this, but the method exists.
+    ---@param self WldUIProvider
+    ---@param elapsedTime number
     UpdateLoadingDialog = function(self, elapsedTime)
     end,
 
+    --- Called by the engine when the world finishes loading.
+    ---@param self WldUIProvider
     StopLoadingDialog = function(self)
     end,
 
+    --- Called by the engine when the world is loaded locally but online clients aren't ready.
+    ---@param self WldUIProvider
     StartWaitingDialog = function(self)
     end,
 
+    --- Engine never calls this, but the method exists.
+    ---@param self WldUIProvider
+    ---@param elapsedTime number
     UpdateWaitingDialog = function(self, elapsedTime)
     end,
 
+    --- Called by the engine when all online clients become ready.
+    ---@param self WldUIProvider
     StopWaitingDialog = function(self)
     end,
 
+    --- Called by the engine after prefetching textures.
+    ---@param self WldUIProvider
     CreateGameInterface = function(self)
     end,
 
+    --- Called by the engine when ending the game session or closing the app.
+    ---@param self WldUIProvider
     DestroyGameInterface = function(self)
     end,
-    
+
+    --- Called by the engine after `StopLoadingDialog`.
+    ---@param self WldUIProvider
+    ---@return string[]?
     GetPrefetchTextures = function(self)
         return nil
     end,
 }
-


### PR DESCRIPTION
## Description of the proposed changes
Annotate `WldUIProvider`'s engine callbacks and functions related to `WldUIProvider`.

## Testing done on the proposed changes
Reading decompilation. The world ui provider is a singleton so it is easy to track down all usages of it.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
