### PR TITLE
Improve wreckage extraction for map preview

### DIFF
--- a/changelog/features.7269.md
+++ b/changelog/features.7269.md
@@ -1,0 +1,1 @@
+- Improved wreckae detection for lobby map preview. (#7269)

--- a/lua/ui/controls/resmappreview.lua
+++ b/lua/ui/controls/resmappreview.lua
@@ -155,30 +155,19 @@ ResourceMapPreview = ClassUI(Group) {
         -- Add the wreckage, if activated. (done first so the important things appear on top)
         local wreckagemarkers = {}
         if enableWreckage then
-            local armies = mapdata.Scenario.Armies
-
-            for _, army in armies do
-                -- This is so spectacularly brittle it's magnificent.
-                if army.Units and army.Units.Units and army.Units.Units.WRECKAGE and army.Units.Units.WRECKAGE.Units then
-                    for k, v in army.Units.Units.WRECKAGE.Units do
-                        -- Some maps have extra entities in the Units list, representing groups.
-                        -- Very annoying, so let's check for the fields we care about.
-                        if v.Position then
-                            local marker = self.wreckageIconPool:Get()
-                            table.insert(wreckagemarkers, marker)
-                            if scenarioInfo.hidePreviewMarkers then
-                                marker:Hide()
-                            else
-                                marker:Show()
-                            end
-
-                            -- Yes, these ones have a capital Position, but the others have a lowercase.
-                            LayoutHelpers.AtLeftTopIn(marker, self.mapPreview,
-                                xOffset + (v.Position[1] / mWidth) * (self.size - 2) * xFactor,
-                                yOffset + (v.Position[3] / mHeight) * (self.size - 2) * yFactor)
-                        end
-                    end
+            for _, pos in MapUtil.GetWreckagePositions(mapdata.Scenario) do
+                local marker = self.wreckageIconPool:Get()
+                table.insert(wreckagemarkers, marker)
+                if scenarioInfo.hidePreviewMarkers then
+                    marker:Hide()
+                else
+                    marker:Show()
                 end
+
+                -- Yes, these ones have a capital Position, but the others have a lowercase.
+                LayoutHelpers.AtLeftTopIn(marker, self.mapPreview,
+                    xOffset + (pos[1] / mWidth) * (self.size - 2) * xFactor,
+                    yOffset + (pos[3] / mHeight) * (self.size - 2) * yFactor)
             end
         end
         self.wreckagemarkers = wreckagemarkers

--- a/lua/ui/maputil.lua
+++ b/lua/ui/maputil.lua
@@ -586,4 +586,58 @@ function GetStartPositionsFromScenario(scenarioInfo, scenarioSave)
     return output
 end
 
+---Returns all units' (leaf nodes) positions under the specified group.
+---@param tblNode? table
+---@param positions? Vector[]
+---@return Vector[]
+local function extractUnitPositions(tblNode, positions)
+    positions = positions or {}
+    if not tblNode then return positions end
+
+    for strName, tblData in pairs(tblNode.Units) do
+        if tblData.type == 'GROUP' then
+            positions = extractUnitPositions(tblData, positions)
+        else
+            table.insert(positions, tblData.Position)
+        end
+    end
+
+    return positions
+end
+
+---Extracts wreckage positions from all groups that contain `"wreck"` in their name.
+---@param tblNode? table
+---@param positions? Vector[]
+---@return Vector[]
+local function extractPositionsFromWreckageGroups(tblNode, positions)
+    positions = positions or {}
+    if not tblNode then return positions end
+
+    for strName, tblData in pairs(tblNode.Units) do
+        if tblData.type == 'GROUP' then
+            if string.find(string.lower(strName), "wreck") then
+                positions = extractUnitPositions(tblData, positions)
+            else
+                positions = extractPositionsFromWreckageGroups(tblData, positions)
+            end
+        end
+    end
+
+    return positions
+end
+
+---Returns all unit wreckage positions. Extracted from army groups that contain `"wreck"` in their name.
+---@param scenario UIScenarioSaveFile
+---@return Vector[]
+function GetWreckagePositions(scenario)
+    ---@type Vector[]
+    local positions = {}
+
+    for _, army in pairs(scenario.Armies) do
+        positions = extractPositionsFromWreckageGroups(army.Units, positions)
+    end
+
+    return positions
+end
+
 --#endregion


### PR DESCRIPTION
## Description of the proposed changes
Instead of the shallow lookup for `WRECKAGE` group, so a full sweep of all groups and get positions from any group that contains `wreck`.

`WRECKAGE` group is a naming convention for a group that is automatically spawned on game start, but there might be more wreck groups spawned later by map script.

<img width="1095" height="587" alt="ForgedAlliance_2026-09-01_23-56-43" src="https://github.com/user-attachments/assets/a843d8d7-d3b4-4a93-8234-a956d43c15a1" />

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [x] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wreckage marker detection in lobby map previews.
  * Wreckage markers now appear more reliably when wreckage is stored in different army and group structures.
  * Marker visibility and tracking behavior remain unchanged.
  * Marker positions continue to be placed accurately on the map.
  * Maps with nested wreckage groups now display their available wreckage markers more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->