### PR TITLE
Make restart session keybind also restart replays

### DIFF
--- a/changelog/snippets/category.7276.md
+++ b/changelog/snippets/category.7276.md
@@ -1,0 +1,1 @@
+- Your explanation here... [Don't forget to change the category in the filename] (#7276).

--- a/lua/keymap/debugKeyActions.lua
+++ b/lua/keymap/debugKeyActions.lua
@@ -214,7 +214,7 @@ local keyActionsDebug = {
         category = 'game',
     },
     ['debug_restart_session'] = {
-        action = "UI_Lua if SessionIsReplay() then LaunchReplaySession(GetFrontEndData('replay_filename')) else RestartSession() end",
+        action = "UI_Lua import('/lua/keymap/misckeyactions.lua').RestartSessionOrReplay()",
         category = 'debug',
     },
     ['debug_toggle_pannels'] = {

--- a/lua/keymap/debugKeyActions.lua
+++ b/lua/keymap/debugKeyActions.lua
@@ -214,7 +214,7 @@ local keyActionsDebug = {
         category = 'game',
     },
     ['debug_restart_session'] = {
-        action = 'UI_Lua RestartSession()',
+        action = "UI_Lua if SessionIsReplay() then LaunchReplaySession(GetFrontEndData('replay_filename')) else RestartSession() end",
         category = 'debug',
     },
     ['debug_toggle_pannels'] = {

--- a/lua/keymap/misckeyactions.lua
+++ b/lua/keymap/misckeyactions.lua
@@ -693,3 +693,17 @@ SelectCommander = function(zoomTo)
         UIZoomTo(selectedUnits, 0)
     end
 end
+
+function RestartSessionOrReplay()
+    if SessionIsReplay() then
+        local ok = LaunchReplaySession(GetFrontEndData('replay_filename'))
+        if not ok then
+            local filename = tostring(GetFrontEndData('replay_filename'))
+            local msg = string.format('Issue starting replay "%s"', filename)
+            print(msg)
+            WARN(msg)
+        end
+    else
+        RestartSession()
+    end
+end

--- a/lua/keymap/misckeyactions.lua
+++ b/lua/keymap/misckeyactions.lua
@@ -703,7 +703,7 @@ function RestartSessionOrReplay()
             print(msg)
             WARN(msg)
         end
-    else
+    elseif SessionIsActive() and SessionCanRestart() then
         RestartSession()
     end
 end


### PR DESCRIPTION
## Description of the proposed changes
- Make restart session keybind also restart replays
- add some guards for it

## Testing done on the proposed changes
You can restart replays launched using the instructions in #7274.

## Checklist
- [x] Changes are annotated, including comments where useful
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
