### PR TITLE
Specify process of splitting large changes in contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Sometimes it's necessary to test changes in a real game to be able to decide if 
 Once there is approval from a conceptual point of view, tick the box in the PR description. This way possible reviewers know that a technical review is the only step left to do when they have a look at the overview list of PRs.
 Reviewers don't like to spend time on PRs that might never make it into the game, so they will probably ignore PRs that don't have this box set.
 
-Nobody likes to review huge PRs. Try to keep PRs small to make reviews easier. If you have to make extensive changes, consider splitting them into one PR that only contains refactoring without any functional changes and one that contains the actual changes to functionality. You can also try splitting big features into multiple PRs.
+Nobody likes to review huge PRs. Try to keep PRs small to make reviews easier. If you have to make extensive changes, consider splitting them into multiple [stacked PRs](https://docs.github.com/en/pull-requests/get-started/about-stacked-prs), or for medium-sized changes, into easy-to-review "atomic" commits. For example, you can split extensive changes into PRs/commits for refactors that do not change functionality, and into PRs/commits that change one piece of functionality at a time.
 
 
 ## How to do a review:

--- a/changelog/snippets/category.7281.md
+++ b/changelog/snippets/category.7281.md
@@ -1,0 +1,1 @@
+- Your explanation here... [Don't forget to change the category in the filename] (#XYZW).

--- a/changelog/snippets/category.7281.md
+++ b/changelog/snippets/category.7281.md
@@ -1,1 +1,0 @@
-- Your explanation here... [Don't forget to change the category in the filename] (#XYZW).


### PR DESCRIPTION
## Description of the proposed changes
Specify process of splitting large changes in contributing guidelines. This is just a practice PR for stacking.

## Testing done on the proposed changes
First, in the top bar, change the PR base from `develop` to the original PR you want to stack onto:
<img width="977" height="184" alt="{FA778672-0DB2-4E2F-9E97-E6FB79E4660B}" src="https://github.com/user-attachments/assets/d3d58b81-8ae2-4f6d-a69e-08bf7b978663" />

Then, below the PR description textbox, start a pull request stack:
<img width="999" height="261" alt="{DAE93E4C-33F4-44FB-9E31-9EDED5F6BAE4}" src="https://github.com/user-attachments/assets/fec8e13c-96de-456f-9a4c-5a5cbc884ab9" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated pull request guidance to recommend splitting extensive work into stacked pull requests or atomic commits.
  - Clarified that refactoring and incremental functionality changes should be submitted separately.
  - These guidelines make larger changes easier to review and help keep individual contributions focused.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->