### PR TITLE
Add guards in fire beetle target tracker thread

### DIFF
--- a/changelog/snippets/fix.7283.md
+++ b/changelog/snippets/fix.7283.md
@@ -1,0 +1,1 @@
+- Your explanation here... [Don't forget to change the category in the filename] (#7283).

--- a/units/XRL0302/XRL0302_Script.lua
+++ b/units/XRL0302/XRL0302_Script.lua
@@ -15,6 +15,7 @@ local DamageArea = DamageArea
 local CreateEmitterAtBone = CreateEmitterAtBone
 local CreateDecal = CreateDecal
 local CreateLightParticle = CreateLightParticle
+local IsDestroyed = IsDestroyed
 
 local DeathWeaponKamikaze = ClassWeapon(Weapon) {
     OnFire = function(self)

--- a/units/XRL0302/XRL0302_Script.lua
+++ b/units/XRL0302/XRL0302_Script.lua
@@ -110,21 +110,19 @@ XRL0302 = ClassUnit(CWalkingLandUnit) {
         local weapon = self:GetWeaponByLabel('Suicide')
         if not weapon then return end
 
-        while not IsDestroyed(self) do
+        while not IsDestroyed(self) and not IsDestroyed(weapon) do
 
             -- adjust behavior of the weapon so it only fires when we're trying to attack something
-            if not IsDestroyed(weapon) then
-                if (
-                    -- we're trying to attack
-                    self:IsUnitState('Attacking') or
-                        -- engineer trying to take us
-                        self:IsUnitState('BeingCaptured') or self:IsUnitState('BeingReclaimed')
-                    )
-                then
-                    weapon:SetEnabled(true)
-                else
-                    weapon:SetEnabled(false)
-                end
+            if (
+                -- we're trying to attack
+                self:IsUnitState('Attacking') or
+                    -- engineer trying to take us
+                    self:IsUnitState('BeingCaptured') or self:IsUnitState('BeingReclaimed')
+                )
+            then
+                weapon:SetEnabled(true)
+            else
+                weapon:SetEnabled(false)
             end
 
             -- adjust behavior of tracking a target so that we speed through the target instead of bump into it

--- a/units/XRL0302/XRL0302_Script.lua
+++ b/units/XRL0302/XRL0302_Script.lua
@@ -106,12 +106,14 @@ XRL0302 = ClassUnit(CWalkingLandUnit) {
     ---@param self XRL0302
     TrackTargetThread = function(self)
         local navigator = self:GetNavigator()
+        if not navigator then return end
         local weapon = self:GetWeaponByLabel('Suicide')
+        if not weapon then return end
 
         while not IsDestroyed(self) do
 
             -- adjust behavior of the weapon so it only fires when we're trying to attack something
-            if weapon then
+            if not IsDestroyed(weapon) then
                 if (
                     -- we're trying to attack
                     self:IsUnitState('Attacking') or
@@ -129,7 +131,7 @@ XRL0302 = ClassUnit(CWalkingLandUnit) {
             local command = self:GetCommandQueue()[1]
             if command and command.commandType == 10 then
                 local target = command.target
-                if target then
+                if not IsDestroyed(target) then
                     navigator:SetDestUnit(target)
                     navigator:SetSpeedThroughGoal(true)
                 end


### PR DESCRIPTION
## Description of the proposed changes
Solves errors in replay 27759573 (faf beta version bf1e5fed9486db129cfaf5e4d7dba4acbee6110f)
```
warning: Error running lua script: ...\gamedata\units.nx4\units\xrl0302\xrl0302_script.lua(133): Game object has been destroyed
         stack traceback:
         	[C]: in function `SetDestUnit'
         	...\gamedata\units.nx4\units\xrl0302\xrl0302_script.lua(133): in function <...\gamedata\units.nx4\units\xrl0302\xrl0302_script.lua:107>
```
```
warning: Error running lua script: ...\gamedata\units.nx4\units\xrl0302\xrl0302_script.lua(124): Game object has been destroyed
         stack traceback:
         	[C]: in function `SetEnabled'
         	...\gamedata\units.nx4\units\xrl0302\xrl0302_script.lua(124): in function <...\gamedata\units.nx4\units\xrl0302\xrl0302_script.lua:107>
```

## Testing done on the proposed changes


## Additional context
<!-- Add any other context about the pull request here. -->


## Checklist
- [ ] Changes are annotated, including comments where useful
- [ ] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).
