### PR TITLE
Add IsDestroyed guard to FlagShield callback

### DIFF
--- a/changelog/snippets/fix.7284.md
+++ b/changelog/snippets/fix.7284.md
@@ -1,0 +1,1 @@
+- Your explanation here... [Don't forget to change the category in the filename] (#7284).

--- a/changelog/snippets/fix.7284.md
+++ b/changelog/snippets/fix.7284.md
@@ -1,1 +1,1 @@
-- Your explanation here... [Don't forget to change the category in the filename] (#7284).
+- Fix error when issuing an assist order to a mobile shield/deceiver with a destroyed unit in the selection (#7284). This should fix mobile shields sometimes stopping in range of enemies while assisting another unit, instead of continuing to move.

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -339,6 +339,7 @@ Callbacks.FlagShield = function(data, units)
     if units and target then
         for k, u in units do
             if not IsDestroyed(u) and u.PointerEnabled == true then
+                ---@cast u UAL0307 | UEL0307 | URL0306 | XSL0307
                 u.PointerEnabled = false --turn the pointer flag off
                 u:DisablePointer() --turn the pointer off
             end

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -338,7 +338,7 @@ Callbacks.FlagShield = function(data, units)
     local target = GetEntityById(data.target)
     if units and target then
         for k, u in units do
-            if IsEntity(u) and not IsDestroyed(u) and u.PointerEnabled == true then
+            if not IsDestroyed(u) and u.PointerEnabled == true then
                 u.PointerEnabled = false --turn the pointer flag off
                 u:DisablePointer() --turn the pointer off
             end

--- a/lua/SimCallbacks.lua
+++ b/lua/SimCallbacks.lua
@@ -338,7 +338,7 @@ Callbacks.FlagShield = function(data, units)
     local target = GetEntityById(data.target)
     if units and target then
         for k, u in units do
-            if IsEntity(u) and u.PointerEnabled == true then
+            if IsEntity(u) and not IsDestroyed(u) and u.PointerEnabled == true then
                 u.PointerEnabled = false --turn the pointer flag off
                 u:DisablePointer() --turn the pointer off
             end

--- a/units/UAL0307/UAL0307_script.lua
+++ b/units/UAL0307/UAL0307_script.lua
@@ -49,8 +49,10 @@ UAL0307 = ClassUnit(AShieldHoverLandUnit, ShieldEffectsComponent) {
     end,
 
     DisablePointer = function(self)
-        self.TargetPointer:SetFireTargetLayerCaps('None') --this disables the stop feature - note that its reset on layer change!
-        self.PointerRestartThread = self.Trash:Add(ForkThread(self.PointerRestart,self))
+        if not IsDestroyed(self.TargetPointer) then            
+            self.TargetPointer:SetFireTargetLayerCaps('None') --this disables the stop feature - note that its reset on layer change!
+            self.PointerRestartThread = self.Trash:Add(ForkThread(self.PointerRestart,self))
+        end
     end,
 
     PointerRestart = function(self)

--- a/units/UAL0307/UAL0307_script.lua
+++ b/units/UAL0307/UAL0307_script.lua
@@ -51,12 +51,11 @@ UAL0307 = ClassUnit(AShieldHoverLandUnit, ShieldEffectsComponent) {
     DisablePointer = function(self)
         if not IsDestroyed(self.TargetPointer) then            
             self.TargetPointer:SetFireTargetLayerCaps('None') --this disables the stop feature - note that its reset on layer change!
-            self.PointerRestartThread = self.Trash:Add(ForkThread(self.PointerRestart,self))
+            self.PointerRestartThread = self.Trash:Add(ForkThread(self.PointerRestart, self))
         end
     end,
 
     PointerRestart = function(self)
-        --sadly i couldnt find some way of doing this without a thread. dont know where to check if its still assisting other than this.
         while self.PointerEnabled == false do
             WaitTicks(11)
             if IsDestroyed(self) or IsDestroyed(self.TargetPointer) then

--- a/units/UEL0307/UEL0307_script.lua
+++ b/units/UEL0307/UEL0307_script.lua
@@ -92,17 +92,12 @@ UEL0307 = ClassUnit(TShieldLandUnit, ShieldEffectsComponent) {
     end,
 
     PointerRestart = function(self)
-        --sadly i couldnt find some way of doing this without a thread. dont know where to check if its still assisting other than this.
         while not self.PointerEnabled do
-
-            WaitSeconds(1)
-
-            -- break if we're a gooner
+            WaitTicks(11)
             if IsDestroyed(self) or IsDestroyed(self.TargetPointer) then
                 break
             end
 
-            -- if not gooner, check whether we need to enable our weapon to keep reasonable distance
             if not self:GetGuardedUnit() then
                 self.PointerEnabled = true
                 self.TargetPointer:SetFireTargetLayerCaps(self.TargetLayerCaps[self.Layer]) --this resets the stop feature - note that its reset on layer change!

--- a/units/UEL0307/UEL0307_script.lua
+++ b/units/UEL0307/UEL0307_script.lua
@@ -85,8 +85,10 @@ UEL0307 = ClassUnit(TShieldLandUnit, ShieldEffectsComponent) {
     end,
 
     DisablePointer = function(self)
-        self.TargetPointer:SetFireTargetLayerCaps('None') --this disables the stop feature - note that its reset on layer change!
-        self.PointerRestartThread = self:ForkThread(self.PointerRestart)
+        if not IsDestroyed(self.TargetPointer) then
+            self.TargetPointer:SetFireTargetLayerCaps('None') --this disables the stop feature - note that its reset on layer change!
+            self.PointerRestartThread = self:ForkThread(self.PointerRestart)
+        end
     end,
 
     PointerRestart = function(self)

--- a/units/URL0306/URL0306_Script.lua
+++ b/units/URL0306/URL0306_Script.lua
@@ -56,16 +56,19 @@ URL0306 = ClassUnit(CLandUnit) {
     DisablePointer = function(self)
         if not IsDestroyed(self.TargetPointer) then
             self.TargetPointer:SetFireTargetLayerCaps('None') --this disables the stop feature - note that its reset on layer change!
-            local thread = ForkThread(self.PointerRestart,self)
+            local thread = ForkThread(self.PointerRestart, self)
             self.Trash:Add(thread)
             self.PointerRestartThread = thread
         end
     end,
 
     PointerRestart = function(self)
-        --sadly i couldnt find some way of doing this without a thread. dont know where to check if its still assisting other than this.
         while self.PointerEnabled == false do
             WaitTicks(11)
+            if IsDestroyed(self) or IsDestroyed(self.TargetPointer) then
+                break
+            end
+
             if not self:GetGuardedUnit() then
                 self.PointerEnabled = true
                 self.TargetPointer:SetFireTargetLayerCaps(self.TargetLayerCaps[self.Layer]) --this resets the stop feature - note that its reset on layer change!

--- a/units/URL0306/URL0306_Script.lua
+++ b/units/URL0306/URL0306_Script.lua
@@ -54,10 +54,12 @@ URL0306 = ClassUnit(CLandUnit) {
     end,
 
     DisablePointer = function(self)
-        self.TargetPointer:SetFireTargetLayerCaps('None') --this disables the stop feature - note that its reset on layer change!
-        local thread = ForkThread(self.PointerRestart,self)
-        self.Trash:Add(thread)
-        self.PointerRestartThread = thread
+        if not IsDestroyed(self.TargetPointer) then
+            self.TargetPointer:SetFireTargetLayerCaps('None') --this disables the stop feature - note that its reset on layer change!
+            local thread = ForkThread(self.PointerRestart,self)
+            self.Trash:Add(thread)
+            self.PointerRestartThread = thread
+        end
     end,
 
     PointerRestart = function(self)

--- a/units/XSL0307/XSL0307_script.lua
+++ b/units/XSL0307/XSL0307_script.lua
@@ -47,11 +47,13 @@ XSL0307 = ClassUnit(SShieldHoverLandUnit, ShieldEffectsComponent) {
 
     ---@param self XSL0307
     DisablePointer = function(self)
-        self.TargetPointer:SetFireTargetLayerCaps('None')
+        if not IsDestroyed(self.TargetPointer) then
+            self.TargetPointer:SetFireTargetLayerCaps('None')
 
-        local thread = ForkThread(self.PointerRestart, self)
-        self.Trash:Add(thread)
-        self.PointerRestartThread = thread
+            local thread = ForkThread(self.PointerRestart, self)
+            self.Trash:Add(thread)
+            self.PointerRestartThread = thread
+        end
     end,
 
     ---@param self XSL0307


### PR DESCRIPTION
## Description of the proposed changes
Solves errors in replay 27759573 (faf beta version bf1e5fed9486db129cfaf5e4d7dba4acbee6110f)
```
warning: Error running sim lua callback function 'FlagShield':
         ...\gamedata\units.nx4\units\uel0307\uel0307_script.lua(88): Game object has been destroyed
         stack traceback:
         	[C]: in function `SetFireTargetLayerCaps'
         	...\gamedata\units.nx4\units\uel0307\uel0307_script.lua(88): in function `DisablePointer'
         	...data\faforever\gamedata\lua.nx4\lua\simcallbacks.lua(316): in function `fn'
         	...data\faforever\gamedata\lua.nx4\lua\simcallbacks.lua(63): in function <...data\faforever\gamedata\lua.nx4\lua\simcallbacks.lua:59>
```

## Testing done on the proposed changes


## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed assist orders involving mobile shields and deceivers so they no longer stop prematurely near enemies when selected units are destroyed.
  * Prevented errors when pointer weapons or their targets are destroyed before pointer-disabling actions complete.
  * Improved handling of shield-related callbacks for units that are no longer available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->