### PR TITLE
Fix error in recall.lua when switching armies in non-team games.

### DIFF
--- a/changelog/snippets/category.7285.md
+++ b/changelog/snippets/category.7285.md
@@ -1,0 +1,1 @@
+- Your explanation here... [Don't forget to change the category in the filename] (#7285).

--- a/changelog/snippets/category.7285.md
+++ b/changelog/snippets/category.7285.md
@@ -1,1 +1,0 @@
-- Your explanation here... [Don't forget to change the category in the filename] (#7285).

--- a/changelog/snippets/fix.7285.md
+++ b/changelog/snippets/fix.7285.md
@@ -1,0 +1,1 @@
+- Fix error in `/sim/recall.lua` when switching armies in non-team games (#7285).

--- a/lua/sim/Recall.lua
+++ b/lua/sim/Recall.lua
@@ -124,7 +124,7 @@ function ArmyRecallRequestCooldown(army)
     if brain:IsDefeated() then
         return "observer"
     end
-    if ScenarioInfo.RecallDisabled then
+    if ScenarioInfo.RecallDisabled or not ScenarioInfo.TeamGame then
         return "scenario"
     end
     if brain.RecallVote ~= nil then

--- a/lua/sim/Recall.lua
+++ b/lua/sim/Recall.lua
@@ -25,20 +25,16 @@ local SyncAnnouncement = import("/lua/simdiplomacy.lua").SyncAnnouncement
 ---@field package RecallVote boolean
 
 function init()
-    if not ScenarioInfo.TeamGame then
-        SyncCannotRequestRecall("scenario")
-    else
-        -- setup sim recall state in the brains
-        local playerCooldown = PlayerGateCooldown - PlayerRequestCooldown
-        local teamCooldown = PlayerGateCooldown - TeamVoteCooldown
-        for _, brain in ArmyBrains do
-            brain.LastRecallRequestTime = playerCooldown
-            brain.LastRecallVoteTime = teamCooldown
-        end
-
-        -- setup user recall state notifier in this thread
-        SyncRecallStatus()
+    -- setup sim recall state in the brains
+    local playerCooldown = PlayerGateCooldown - PlayerRequestCooldown
+    local teamCooldown = PlayerGateCooldown - TeamVoteCooldown
+    for _, brain in ArmyBrains do
+        brain.LastRecallRequestTime = playerCooldown
+        brain.LastRecallVoteTime = teamCooldown
     end
+
+    -- setup user recall state notifier in this thread
+    SyncRecallStatus()
 end
 
 function OnArmyChange()

--- a/lua/sim/Recall.lua
+++ b/lua/sim/Recall.lua
@@ -493,7 +493,7 @@ local function SyncRecallStatusThread()
 end
 
 function SyncRecallStatus()
-    if UserRecallStatusThread then
+    if not IsDestroyed(UserRecallStatusThread) then
         ResumeThread(UserRecallStatusThread) -- force update the existing thread
     else
         UserRecallStatusThread = ForkThread(SyncRecallStatusThread)

--- a/lua/sim/Recall.lua
+++ b/lua/sim/Recall.lua
@@ -19,6 +19,11 @@ local SyncAnnouncement = import("/lua/simdiplomacy.lua").SyncAnnouncement
 ---| "vote"
 ---| "observer"
 
+---@class AIBrain
+---@field package LastRecallRequestTime number
+---@field package LastRecallVoteTime number
+---@field package RecallVote boolean
+
 function init()
     if not ScenarioInfo.TeamGame then
         SyncCannotRequestRecall("scenario")


### PR DESCRIPTION
<!-- General useful tooling:
    - [ScreenToGif](https://www.screentogif.com/): Free, open source screen recorder that can export to MP4. If the changes are visual, these can help you tell us exactly what the changes imply!
-->
<!-- Feel free to remove unused parts of this template. -->

## Description of the proposed changes
Fixes the following errors seen at version 929507f922b267329d40ba14f51dcda6da2593f9 when switching from a player army to a civilian army, and then back again.
```
warning: Error running lua script: ...\lua\sim\recall.lua(143): call expected but got table
         stack traceback:
         	...\lua\sim\recall.lua(143): in function `ArmyRecallRequestCooldown'
         	...\lua\sim\recall.lua(484): in function <...\lua\sim\recall.lua:475>
```
```
warning: Error running lua script: ...\lua\sim\recall.lua(101): attempt to perform arithmetic on local `lastPlayerRequest' (a nil value)
         stack traceback:
         	...\lua\sim\recall.lua(101): in function <...\lua\sim\recall.lua:92>
         	(tail call): ?
         	...\lua\sim\recall.lua(476): in function <...\lua\sim\recall.lua:475>
```
After the thread errors, it is killed and the following error occurs when switching again:
```
warning: Attempted to resume a thread that was already killed
         stack traceback:
         	[C]: in function `ResumeThread'
         	...\lua\sim\recall.lua(492): in function `SyncRecallStatus'
         	...\lua\sim\recall.lua(434): in function `ResyncRecallVoting'
         	...\lua\sim\recall.lua(44): in function `OnArmyChange'
         	...\lua\simsync.lua(161): in function `NoteFocusArmyChanged'
```

These errors were caused by #7237, since it made `LastRecallVoteTime` no longer exist as a field in the brain in non-team games. It was expected to be fine since non-team games weren't running the main recall thread anyway, but it ended up being that the thread gets run upon switching armies.
since it disabled the `LastRecallVoteTime` being a field in the brain, which was expected to be fine since no threads were meant to run in that scenario, but the changes didn't account for logic run by army switching.

I went with reverting #7237 and instead putting the `TeamGame` condition in `ArmyRecallRequestCooldown` because a script may change `ScenarioInfo.TeamGame`, at which point all the recall infrastructure needs to exist and run normally.

## Testing done on the proposed changes
The errors no longer occur when switching between armies.
The recall button is disabled in a non-teamgame scenario.

## Checklist
- [x] Changes are annotated, including comments where useful
- [x] Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- [ ] Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an error that could occur when switching armies in non-team games.
  - Recall requests are now correctly blocked when recall is unavailable or the match is not a team game.
  - Improved status synchronization and handling of invalid status updates during recall initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->