### PR TITLE
Add backwards compat for nomads' formation hook

### DIFF
--- a/changelog/snippets/fix.7289.md
+++ b/changelog/snippets/fix.7289.md
@@ -1,1 +1,1 @@
-- Your explanation here... [Don't forget to change the category in the filename] (#7289).
+- Add backwards compatibility for the naval formation changes in Nomads (#7289).

--- a/changelog/snippets/fix.7289.md
+++ b/changelog/snippets/fix.7289.md
@@ -1,0 +1,1 @@
+- Your explanation here... [Don't forget to change the category in the filename] (#7289).

--- a/lua/formations.lua
+++ b/lua/formations.lua
@@ -1431,3 +1431,20 @@ end
 
 --#endregion
 --#endregion
+
+---#region Backwards compatibility
+-- Categories used in Nomads that were moved to categorizeUnits.lua
+
+local LightAttackNaval = categories.LIGHTBOAT
+local FrigateNaval = categories.FRIGATE
+local SubNaval = categories.T1SUBMARINE + categories.T2SUBMARINE + (categories.TECH3 * categories.SUBMERSIBLE * categories.ANTINAVY * categories.NAVAL - categories.NUKE)
+local DestroyerNaval = categories.DESTROYER
+local CruiserNaval = categories.CRUISER
+local BattleshipNaval = categories.BATTLESHIP
+local CarrierNaval = categories.NAVALCARRIER
+local NukeSubNaval = categories.NUKESUB - SubNaval
+local MobileSonar = categories.MOBILESONAR
+local DefensiveBoat = categories.DEFENSIVEBOAT
+local RemainingNaval = categories.NAVAL - (LightAttackNaval + FrigateNaval + SubNaval + DestroyerNaval + CruiserNaval + BattleshipNaval +
+                        CarrierNaval + NukeSubNaval + DefensiveBoat + MobileSonar)
+---#endregion


### PR DESCRIPTION
## Description of the proposed changes
Nomads [hooks formations.lua](https://github.com/FAForever/nomads/blob/2fd7a874ae4556558d7844f259737a3b30d27c90/nomadhook/lua/formations.lua#L1-L15) and changes locals that were moved to CategorizeUnits.lua. This PR re-adds those locals so that Nomads stops erroring every time it tries to create formations.

## Testing done on the proposed changes
Append nomads' hook to the end of the file, there were no warnings from intellisense.

## Checklist
- New code is annotated and has comments where useful
- Changes are documented in a changelog snippet according to the [guidelines](https://faforever.github.io/fa/development/changelog#format-of-a-snippet).
- The feature is conceptually approved and the approval documented (see the [explanation](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md)
- Request 2-3 reviewers from the [list of reviewers and their areas of knowledge](https://github.com/FAForever/fa/blob/deploy/fafdevelop/CONTRIBUTING.md#reviewers).

## Approval
- [x] The feature is greenlighted through
  - being a bugfix
<!-- Remove reasons that are not applicable -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility**
  - Preserved compatibility for naval formations following category changes.
  - Existing naval unit groupings continue to recognize attack ships, submarines, surface combatants, carriers, mobile sonar, defensive boats, and other naval units.
  - Submarine classifications continue to distinguish standard submarines from nuclear submarines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->